### PR TITLE
add train_test_split utility function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ scholar-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# ASDF files
+.tool-versions

--- a/lib/scholar/utilities.ex
+++ b/lib/scholar/utilities.ex
@@ -1,0 +1,55 @@
+defmodule Scholar.Utilities do
+  @moduledoc """
+  Utility functions for general purposes.
+  """
+
+  import Nx.Defn
+
+  train_test_split_schema = [
+    train_size: [
+      required: true,
+      type: :float,
+      doc: """
+      Percentual size for the training set.
+      """
+    ]
+  ]
+
+  @train_test_split_schema NimbleOptions.new!(train_test_split_schema)
+
+  @doc ~S"""
+  Split tensors into random train and test subsets.
+
+  ## Options
+
+  #{NimbleOptions.docs(@train_test_split_schema)}
+
+  ## Example
+
+      Split into 80% for training and 20% for testing.
+
+      iex> {_train, _test} = Scholar.Utilities.train_test_split(Nx.tensor([[3, 6, 5], [26, 75, 3], [23, 4, 1]]), train_size: 0.8)
+      {#Nx.Tensor<
+        s64[2][3]
+        [
+          [3, 6, 5],
+          [26, 75, 3]
+        ]
+      >,
+      #Nx.Tensor<
+        s64[1][3]
+        [
+          [23, 4, 1]
+        ]
+      >}
+  """
+  deftransform train_test_split(%Nx.Tensor{} = features_tensor, opts \\ []) do
+    opts = NimbleOptions.validate!(opts, @train_test_split_schema)
+
+    features = Nx.to_list(features_tensor)
+    num_samples = Enum.count(features)
+    split_size = floor(opts[:train_size] * num_samples)
+    {train, test} = Enum.split(features, split_size)
+    {Nx.tensor(train), Nx.tensor(test)}
+  end
+end

--- a/test/scholar/utilities_test.exs
+++ b/test/scholar/utilities_test.exs
@@ -1,0 +1,60 @@
+defmodule Scholar.UtilitiesTest do
+  use Scholar.Case, async: true
+  alias Scholar.Utilities
+  # doctest Utilities
+
+  describe "train_test_split/2" do
+    test "Split into 50% for training and 50% for testing" do
+      tensor = Nx.iota({10, 2}, names: [:x, :y])
+      {train, test} = Utilities.train_test_split(tensor, train_size: 0.5)
+
+      assert Nx.tensor([
+               [0, 1],
+               [2, 3],
+               [4, 5],
+               [6, 7],
+               [8, 9]
+             ]) == train
+
+      assert Nx.tensor([
+               [10, 11],
+               [12, 13],
+               [14, 15],
+               [16, 17],
+               [18, 19]
+             ]) == test
+    end
+
+    test "Split into 70% for training and 30% for testing" do
+      tensor = Nx.iota({100, 6}, names: [:x, :y])
+      {train, test} = Utilities.train_test_split(tensor, train_size: 0.7)
+
+      assert length(Nx.to_list(train)) == 70
+      assert length(Nx.to_list(test)) == 30
+    end
+
+    test "Split into 75% for training and 25% for testing" do
+      tensor = Nx.iota({100, 10}, names: [:x, :y])
+      {train, test} = Utilities.train_test_split(tensor, train_size: 0.75)
+
+      assert length(Nx.to_list(train)) == 75
+      assert length(Nx.to_list(test)) == 25
+    end
+
+    test "Split into 61% for training and 39% for testing" do
+      tensor = Nx.iota({100, 10}, names: [:x, :y])
+      {train, test} = Utilities.train_test_split(tensor, train_size: 0.61)
+
+      assert length(Nx.to_list(train)) == 61
+      assert length(Nx.to_list(test)) == 39
+    end
+
+    test "Split into 60% for training and 40% for testing with unbalanced data" do
+      tensor = Nx.iota({73, 4}, names: [:x, :y])
+      {train, test} = Utilities.train_test_split(tensor, train_size: 0.61)
+
+      assert length(Nx.to_list(train)) == 44
+      assert length(Nx.to_list(test)) == 29
+    end
+  end
+end


### PR DESCRIPTION
I created a simple train_test_split function based on the [roadmap](https://github.com/elixir-nx/scholar/issues/75)

I had some issues with the `doctest `related to syntax error, so I temporally kept it commented.
![Screenshot 2023-05-31 at 22 34 30](https://github.com/elixir-nx/scholar/assets/1058350/a4d1676c-f17c-47fc-921f-320d46277b63)

I also would like some information about `NimbleOptions`, I tried to follow the other examples, but I am unsure whether or not this is correct. 

@josevalim
@msluszniak 
@polvalente 