### PR TITLE
Draft: Adding CountVectorizer & TfidfVectorizer

### DIFF
--- a/lib/scholar/preprocessing/count_vectorizer.ex
+++ b/lib/scholar/preprocessing/count_vectorizer.ex
@@ -1,0 +1,60 @@
+defmodule Scholar.Preprocessing.CountVectorizer do
+  defstruct vocabulary: nil,
+            fixed_vocabulary: false,
+            ngram_range: {1, 1},
+            max_features: nil,
+            min_df: 1.0,
+            max_df: 1.0,
+            stop_words: nil,
+            binary: false
+
+  defp make_ngrams(tokens, ngram_range) do
+    {min_n, max_n} = ngram_range
+    n_original_tokens = length(tokens)
+
+    ngrams =
+      for n <- min_n..min(max_n, n_original_tokens) do
+        for i <- 0..(n_original_tokens - n) do
+          Enum.slice(tokens, i, n) |> Enum.join(" ")
+        end
+      end
+
+    ngrams |> Enum.flat_map(& &1)
+  end
+
+  defp do_process(doc, opts) do
+    {pre_mod, pre_func, pre_args} = opts[:preprocessor]
+    {token_mod, token_func, token_args} = opts[:tokenizer]
+
+    doc
+    |> then(fn doc -> apply(pre_mod, pre_func, [doc | pre_args]) end)
+    |> then(fn doc -> apply(token_mod, token_func, [doc | token_args]) end)
+    |> make_ngrams(opts[:ngram_range])
+    |> Enum.filter(fn token ->
+      if not is_nil(opts[:stop_words]), do: token not in opts[:stop_words], else: true
+    end)
+  end
+
+  def build_vocab(corpus, opts \\ []) do
+    case opts[:vocabulary] do
+      nil ->
+        corpus
+        |> Enum.reduce([], fn doc, vocab ->
+          vocab ++ (doc |> do_process(opts))
+        end)
+        |> Enum.sort()
+        |> Enum.with_index()
+        |> Enum.into(%{})
+
+      _ ->
+        opts[:vocabulary]
+    end
+  end
+
+  def new(corpus, opts \\ []) do
+    opts = Scholar.Preprocessing.Shared.validate_shared!(opts)
+    fixed_vocab = if is_nil(opts[:vocabulary]), do: false, else: true
+    vocab = build_vocab(corpus, opts)
+    struct(__MODULE__, vocabulary: vocab, fixed_vocabulary: fixed_vocab)
+  end
+end

--- a/lib/scholar/preprocessing/shared.ex
+++ b/lib/scholar/preprocessing/shared.ex
@@ -1,0 +1,192 @@
+defmodule Scholar.Preprocessing.Shared do
+  @moduledoc false
+  vectorizer_schema_opts = [
+    ngram_range: [
+      type: {:custom, __MODULE__, :validate_ngram_range, []},
+      default: {1, 1},
+      doc: """
+      The lower and upper boundary of the range of n-values for different n-grams to be extracted.
+      All values of n such that min_n <= n <= max_n will be used.
+      For example an `ngram_range` of `{1, 1}` means only unigrams, `{1, 2}` means unigrams and bigrams,
+      and `{2, 2}` means only bigrams.
+      Only applies if `analyzer` is not callable.
+      """
+    ],
+    max_features: [
+      type: :integer,
+      default: -1,
+      doc: """
+      If not `nil`, build a vocabulary that only consider the top `max_features` ordered by term frequency across the corpus.
+      This parameter is ignored if `vocabulary` is not `nil`.
+      """
+    ],
+    min_df: [
+      type: {:custom, __MODULE__, :in_range, [:closed, 0, 1, :closed]},
+      default: 1.0,
+      doc: """
+      When building the vocabulary ignore terms that have a document frequency strictly lower than the given threshold.
+      This value is also called cut-off in the literature.
+      If float, the parameter represents a proportion of documents, integer absolute counts.
+      This parameter is ignored if `vocabulary` is not `nil`.
+      """
+    ],
+    max_df: [
+      type: {:custom, __MODULE__, :in_range, [:closed, 0, 1, :closed]},
+      default: 1.0,
+      doc: """
+      When building the vocabulary ignore terms that have a document frequency strictly higher than the given threshold.
+      This value is also called cut-off in the literature.
+      If float, the parameter represents a proportion of documents, integer absolute counts.
+      This parameter is ignored if `vocabulary` is not `nil`.
+      """
+    ],
+    stop_words: [
+      type: {:list, :string},
+      default: [],
+      doc: """
+      If `stop_words` is `nil`, no stop words will be used.
+      If `stop_words` is `:english`, a built-in stop word list for English is used.
+      If `stop_words` is a list, that list is assumed to contain stop words, all of which will be removed from the resulting tokens.
+      Only applies if `analyzer` is not callable.
+      """
+    ],
+    binary: [
+      type: :boolean,
+      default: false,
+      doc: """
+      If `true`, all non-zero counts are set to 1.
+      This is useful for discrete probabilistic models that model binary events rather than integer counts.
+      Only applies if `analyzer` is not callable.
+      """
+    ],
+    dtype: [
+      type:
+        {:in,
+         [:u8, :u16, :u32, :u64, :s8, :s16, :s32, :s64, :f16, :f32, :f64, :bf16, :c64, :c128]},
+      default: :f64,
+      doc: """
+      Type of the matrix returned by `fit_transform` or `transform`.
+      Only applies if `analyzer` is not callable.
+      """
+    ],
+    tokenizer: [
+      type: :mfa,
+      default: {String, :split, []},
+      doc: """
+      Provide the tokenization function to use on the corpus.
+      The n-grams generated will use the tokens produced by the tokenizer.
+      Must be in MFA format (e.g. `{Module, :function, arity}`).
+      If `tokenizer` is `nil`, `String.split/2` is used.
+      """
+    ],
+    preprocessor: [
+      type: :mfa,
+      default: {__MODULE__, :default_preprocessor, []},
+      doc: """
+      Override the preprocessing (string transformation) stage while preserving the tokenizing and n-grams generation steps.
+      Must be in MFA format (e.g. `{Module, :function, arity}`).
+      Default performs `String.downcase/1` |> `String.normalize(:nfkd)`.
+      """
+    ],
+    norm: [
+      type: {:in, [:l1, :l2, nil]},
+      default: :l2,
+      doc: """
+      Norm used to normalize term vectors.
+      """
+    ],
+    vocabulary: [
+      type: {:custom, __MODULE__, :validate_vocabulary, []},
+      default: nil,
+      doc: """
+      Either a map where keys are terms and values are indices in the feature matrix, or a list of terms.
+      If `vocabulary` is `nil`, a vocabulary is determined from the input documents.
+      Indices in the vocabulary are expected to be unique.
+      """
+    ]
+  ]
+
+  @vectorizer_schema NimbleOptions.new!(vectorizer_schema_opts)
+
+  def validate_vocabulary(vocabulary) do
+    case vocabulary do
+      nil ->
+        {:ok, nil}
+
+      %MapSet{} ->
+        {:ok, vocabulary |> Enum.sort() |> Enum.with_index() |> Enum.into(%{})}
+
+      _ when is_list(vocabulary) ->
+        {:ok, vocabulary |> Enum.sort() |> Enum.with_index() |> Enum.into(%{})}
+
+      _ when is_map(vocabulary) ->
+        indices = vocabulary |> Map.values() |> MapSet.new()
+
+        unless Enum.count(indices) == Enum.count(vocabulary),
+          do: {:error, "vocabulary indices must be unique"}
+
+        for i <- 0..(Enum.count(vocabulary) - 1) do
+          unless Map.has_key?(vocabulary, i),
+            do: {:error, "Vocabulary of size #{Enum.count(vocabulary)} missing index #{i}"}
+        end
+
+        {:ok, vocabulary}
+
+      _ ->
+        {:error, "vocabulary must be of type Map, MapSet, or List"}
+    end
+  end
+
+  def default_preprocessor(text) do
+    text
+    |> String.downcase()
+    |> String.normalize(:nfkd)
+  end
+
+  def validate_shared!(opts) do
+    NimbleOptions.validate!(opts, @vectorizer_schema)
+  end
+
+  def validate_ngram_range(value = {min, max}) do
+    if min <= max, do: {:ok, value}, else: {:error, "min must be less than or equal to max"}
+  end
+
+  def validate_ngram_range(value) do
+    unless is_tuple(value) and tuple_size(value) == 2,
+      do: {:error, "ngram_range must be a tuple of length 2"}
+  end
+
+  def in_range(value, left_bracket, min, max, right_bracket) do
+    in_range? =
+      case {left_bracket, min, max, right_bracket} do
+        {_, nil, nil, _} ->
+          true
+
+        {_, nil, max, :closed} ->
+          value <= max
+
+        {_, nil, max, :open} ->
+          value < max
+
+        {:closed, min, nil, _} ->
+          value >= min
+
+        {:open, min, nil, _} ->
+          value > min
+
+        {:closed, min, max, :closed} ->
+          value >= min and value <= max
+
+        {:open, min, max, :closed} ->
+          value > min and value <= max
+
+        {:closed, min, max, :open} ->
+          value >= min and value < max
+
+        {:open, min, max, :open} ->
+          value > min and value < max
+      end
+
+    if in_range?, do: {:ok, value}, else: {:error, "Value #{value} is not in range"}
+  end
+end


### PR DESCRIPTION
Adding CountVectorizer and TFIDF Vectorizer very similar to SKLearn's implementation. Based on some work currently being done by @polvalente on Nx to potentially add sparse tensor support (see https://github.com/elixir-nx/nx/tree/pv-proof-of-concept-sparse-torchx) , this would definitely benefit from sparse tensors, but for now I plan on proceeding with dense tensors.

Considering these vectorizers operate on text, perhaps they would best be fit for a standalone NLP library (I have begun scaffolding out a bit of one) but they could also very well fit in here in Scholar.Preprocessing. I'm open to suggestions as to where they best belong. 

As of now, I only have finished setting up the options, and building a vocab given the options. I will try to wrap up at least the CountVectorizer by tomorrow night. 