### PR TITLE
minor grammar fix in integrate/integrate.ex

### DIFF
--- a/lib/scholar/integrate/integrate.ex
+++ b/lib/scholar/integrate/integrate.ex
@@ -17,7 +17,7 @@ defmodule Scholar.Integrate do
     keep_axis: [
       type: :boolean,
       default: false,
-      doc: "If set to true, the axis which is reduced are kept."
+      doc: "If set to true, the axis which is reduced is kept."
     ]
   ]
 


### PR DESCRIPTION
I spotted an error when reading the docs.