### PR TITLE
Update URL reference to "Tackling the Poor Assumptions of Naive Bayes Text Classifiers" (ICML03-081.pdf)

### DIFF
--- a/lib/scholar/naive_bayes/complement.ex
+++ b/lib/scholar/naive_bayes/complement.ex
@@ -8,7 +8,7 @@ defmodule Scholar.NaiveBayes.Complement do
 
   Reference:
 
-  * [1] - [Paper about Complement Naive Bayes Algorithm](https://www.aaai.org/Papers/ICML/2003/ICML03-081.pdf?ref=https://githubhelp.com)
+  * [1] - [Paper about Complement Naive Bayes Algorithm](https://cdn.aaai.org/ICML/2003/ICML03-081.pdf)
   """
   import Nx.Defn
   import Scholar.Shared


### PR DESCRIPTION
The URL has "moved"

```bash
curl -I https://www.aaai.org/Papers/ICML/2003/ICML03-081.pdf?ref=https://githubhelp.com
```

With a 301

```bash
HTTP/2 301
server: nginx
date: Thu, 28 Sep 2023 20:36:36 GMT
content-type: text/html
content-length: 162
location: https://aaai.org/Papers/ICML/2003/ICML03-081.pdf?ref=https://githubhelp.com
```

Which was nice of them, but unfortunately it moved againt

```bash
curl -I https://aaai.org/Papers/ICML/2003/ICML03-081.pdf?ref=https://githubhelp.com
```

As we get a 404 on that "moved" url

```bash
HTTP/2 404
server: nginx
date: Thu, 28 Sep 2023 20:37:14 GMT
content-type: text/html
content-length: 146
vary: Accept-Encoding
```

A duck-duck-go search for the URL is under a CDN now

```bash
curl -I https://cdn.aaai.org/ICML/2003/ICML03-081.pdf
```

Now with a 200 OK

```bash
HTTP/2 200
content-type: application/pdf
content-length: 237413
date: Thu, 28 Sep 2023 20:42:33 GMT
x-amz-replication-status: FAILED
last-modified: Mon, 24 Jul 2023 18:06:28 GMT
etag: "b4287b69cedd0f24b709aaf0a844ba1f"
x-amz-server-side-encryption: AES256
x-amz-meta-s3cmd-attrs: md5:b4287b69cedd0f24b709aaf0a844ba1f
x-amz-version-id: Q5vp3ceBIFGxk9Nokj4_7ibqNL8lUZC2
accept-ranges: bytes
server: AmazonS3
vary: Accept-Encoding
x-cache: Miss from cloudfront
via: 1.1 305fa1d7f9df4e42edba1bba6d0ebb56.cloudfront.net (CloudFront)
x-amz-cf-pop: IAD55-P4
x-amz-cf-id: BDJ8XqxPjaY93CYDwfPsBvm13YLFf6aygwzM0a-6niY6hKSrW35iEQ==
```

I left off the `ref=https://githubhelp.com` as I don't know if that is relevant or not