### PR TITLE
Add mean_tweedie_deviance and particular cases

### DIFF
--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -157,7 +157,7 @@ defmodule Scholar.Metrics.Regression do
         0.18411168456077576
       >
   """
-  deftransform mean_tweedie_deviance(y_true, y_pred, power) do
+  defn mean_tweedie_deviance(y_true, y_pred, power) do
     mean_tweedie_deviance_n(y_true, y_pred, power)
   end
 

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -165,6 +165,8 @@ defmodule Scholar.Metrics.Regression do
   Similar to `mean_tweedie_deviance/3` but raises `RuntimeError` if the
   inputs cannot be used with the given power argument.
 
+  Note: This function cannot be used in `defn`.
+
   ## Examples
 
       iex> y_true = Nx.tensor([1, 1, 1, 1, 1, 2, 2, 1, 3, 1], type: :u32)

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -4,54 +4,54 @@ defmodule Scholar.Metrics.RegressionTest do
   alias Scholar.Metrics.Regression
   doctest Regression
 
-  describe "mean_tweedie_deviance" do
-    test "raise when y_pred <= 0 and power < 0 with check_tensors: true" do
+  describe "mean_tweedie_deviance!/3" do
+    test "raise when y_pred <= 0 and power < 0" do
       power = -1
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
 
-      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
+      assert_raise RuntimeError, ~r/mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance!(y_true, y_pred, power)
       end
     end
 
-    test "raise when y_pred <= 0 and 1 <= power < 2 with check_tensors: true" do
+    test "raise when y_pred <= 0 and 1 <= power < 2" do
       power = 1
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
 
-      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
+      assert_raise RuntimeError, ~r/mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance!(y_true, y_pred, power)
       end
     end
 
-    test "raise when y_pred <= 0 and power >= 2 with check_tensors: true" do
+    test "raise when y_pred <= 0 and power >= 2" do
       power = 2
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
 
-      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
+      assert_raise RuntimeError, ~r/mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance!(y_true, y_pred, power)
       end
     end
 
-    test "raise when y_true < 0 and 1 <= power < 2 with check_tensors: true" do
+    test "raise when y_true < 0 and 1 <= power < 2" do
       power = 1
       y_true = Nx.tensor([-1, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :s32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], type: :s32)
 
-      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
+      assert_raise RuntimeError, ~r/mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance!(y_true, y_pred, power)
       end
     end
 
-    test "raise when y_true <= 0 and power >= 2 with check_tensors: true" do
+    test "raise when y_true <= 0 and power >= 2" do
       power = 2
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :s32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], type: :s32)
 
-      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
+      assert_raise RuntimeError, ~r/mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance!(y_true, y_pred, power)
       end
     end
   end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -5,53 +5,53 @@ defmodule Scholar.Metrics.RegressionTest do
   doctest Regression
 
   describe "mean_tweedie_deviance" do
-    test "raise when y_pred <= 0 and power < 0" do
+    test "raise when y_pred <= 0 and power < 0 with check_tensors: true" do
       power = -1
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
 
       assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
       end
     end
 
-    test "raise when y_pred <= 0 and 1 <= power < 2" do
+    test "raise when y_pred <= 0 and 1 <= power < 2 with check_tensors: true" do
       power = 1
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
 
       assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
       end
     end
 
-    test "raise when y_pred <= 0 and power >= 2" do
+    test "raise when y_pred <= 0 and power >= 2 with check_tensors: true" do
       power = 2
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
 
       assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
       end
     end
 
-    test "raise when y_true < 0 and 1 <= power < 2" do
+    test "raise when y_true < 0 and 1 <= power < 2 with check_tensors: true" do
       power = 1
       y_true = Nx.tensor([-1, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :s32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], type: :s32)
 
       assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
       end
     end
 
-    test "raise when y_true <= 0 and power >= 2" do
+    test "raise when y_true <= 0 and power >= 2 with check_tensors: true" do
       power = 2
       y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :s32)
       y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], type: :s32)
 
       assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
-        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+        Regression.mean_tweedie_deviance(y_true, y_pred, power, check_tensors: true)
       end
     end
   end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -3,4 +3,56 @@ defmodule Scholar.Metrics.RegressionTest do
 
   alias Scholar.Metrics.Regression
   doctest Regression
+
+  describe "mean_tweedie_deviance" do
+    test "raise when y_pred <= 0 and power < 0" do
+      power = -1
+      y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
+      y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
+
+      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+      end
+    end
+
+    test "raise when y_pred <= 0 and 1 <= power < 2" do
+      power = 1
+      y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
+      y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
+
+      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+      end
+    end
+
+    test "raise when y_pred <= 0 and power >= 2" do
+      power = 2
+      y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :u32)
+      y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0], type: :u32)
+
+      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+      end
+    end
+
+    test "raise when y_true < 0 and 1 <= power < 2" do
+      power = 1
+      y_true = Nx.tensor([-1, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :s32)
+      y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], type: :s32)
+
+      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+      end
+    end
+
+    test "raise when y_true <= 0 and power >= 2" do
+      power = 2
+      y_true = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], type: :s32)
+      y_pred = Nx.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], type: :s32)
+
+      assert_raise RuntimeError, ~r/Mean Tweedie deviance/, fn ->
+        Regression.mean_tweedie_deviance(y_true, y_pred, power)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR also adds the particular cases:
- `mean_poisson_deviance`
- `mean_gamma_deviance`

And updates `mean_square_error` to use `mean_tweedie_deviance` as well.