### PR TITLE
Add implementation of lazy_select via defn

### DIFF
--- a/benchmarks/lazy_select_vs_sort.exs
+++ b/benchmarks/lazy_select_vs_sort.exs
@@ -1,0 +1,141 @@
+# mix run benchmarks/lazy_select_vs_sort.exs
+Nx.global_default_backend(EXLA.Backend)
+Nx.Defn.global_default_options(compiler: EXLA)
+
+key = Nx.Random.key(System.os_time())
+
+inputs_knn = %{
+  "10" => elem(Nx.Random.shuffle(key, Nx.iota({10})), 0),
+  "100" => elem(Nx.Random.shuffle(key, Nx.iota({100})), 0),
+  "1000" => elem(Nx.Random.shuffle(key, Nx.iota({1000})), 0),
+  "10000" => elem(Nx.Random.shuffle(key, Nx.iota({10000})), 0),
+  "100000" => elem(Nx.Random.shuffle(key, Nx.iota({100000})), 0)
+}
+
+Benchee.run(
+  %{
+    "lazy_select" => fn x ->
+      EXLA.jit_apply(&Scholar.LazySelect.lazy_select(&1, k: div(Nx.size(&1), 2)), [x])
+    end,
+    "sort" => fn x ->
+      EXLA.jit_apply(&Nx.sort(&1), [x])[div(Nx.size(x), 2)]
+    end,
+  },
+  time: 10,
+  memory_time: 2,
+  inputs: inputs_knn
+)
+
+
+# 22:55:47.179 [info] TfrtCpuClient created.
+# Operating System: Linux
+# CPU Information: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
+# Number of Available Cores: 6
+# Available memory: 15.61 GB
+# Elixir 1.15.5
+# Erlang 26.1.2
+
+# Benchmark suite executing with the following configuration:
+# warmup: 2 s
+# time: 10 s
+# memory time: 2 s
+# reduction time: 0 ns
+# parallel: 1
+# inputs: 10, 100, 1000, 10000, 100000
+# Estimated total run time: 2.33 min
+
+# Benchmarking lazy_select with input 10 ...
+# Benchmarking lazy_select with input 100 ...
+# Benchmarking lazy_select with input 1000 ...
+# Benchmarking lazy_select with input 10000 ...
+# Benchmarking lazy_select with input 100000 ...
+# Benchmarking sort with input 10 ...
+# Benchmarking sort with input 100 ...
+# Benchmarking sort with input 1000 ...
+# Benchmarking sort with input 10000 ...
+# Benchmarking sort with input 100000 ...
+
+# ##### With input 10 #####
+# Name                  ips        average  deviation         median         99th %
+# lazy_select       61.12 K       16.36 μs   ±164.20%       13.69 μs       55.52 μs
+# sort              22.62 K       44.20 μs   ±140.67%       36.76 μs      158.98 μs
+
+# Comparison:
+# lazy_select       61.12 K
+# sort              22.62 K - 2.70x slower +27.84 μs
+
+# Memory usage statistics:
+
+# Name           Memory usage
+# lazy_select         3.84 KB
+# sort               15.15 KB - 3.95x memory usage +11.31 KB
+
+# **All measurements for memory usage were the same**
+
+# ##### With input 100 #####
+# Name                  ips        average  deviation         median         99th %
+# lazy_select       40.76 K       24.54 μs   ±110.57%       21.23 μs       76.69 μs
+# sort              19.65 K       50.89 μs   ±145.68%       42.19 μs      167.57 μs
+
+# Comparison:
+# lazy_select       40.76 K
+# sort              19.65 K - 2.07x slower +26.36 μs
+
+# Memory usage statistics:
+
+# Name           Memory usage
+# lazy_select         3.84 KB
+# sort               15.15 KB - 3.95x memory usage +11.31 KB
+
+# **All measurements for memory usage were the same**
+
+# ##### With input 1000 #####
+# Name                  ips        average  deviation         median         99th %
+# sort               6.40 K      156.32 μs    ±95.19%      143.73 μs      251.71 μs
+# lazy_select        5.38 K      185.86 μs    ±62.22%      175.89 μs      293.33 μs
+
+# Comparison:
+# sort               6.40 K
+# lazy_select        5.38 K - 1.19x slower +29.54 μs
+
+# Memory usage statistics:
+
+# Name           Memory usage
+# sort               15.15 KB
+# lazy_select         3.84 KB - 0.25x memory usage -11.31250 KB
+
+# **All measurements for memory usage were the same**
+
+# ##### With input 10000 #####
+# Name                  ips        average  deviation         median         99th %
+# sort               624.70        1.60 ms    ±23.14%        1.58 ms        2.02 ms
+# lazy_select         86.37       11.58 ms     ±3.98%       11.50 ms       12.96 ms
+
+# Comparison:
+# sort               624.70
+# lazy_select         86.37 - 7.23x slower +9.98 ms
+
+# Memory usage statistics:
+
+# Name           Memory usage
+# sort               15.15 KB
+# lazy_select         3.84 KB - 0.25x memory usage -11.31250 KB
+
+# **All measurements for memory usage were the same**
+
+# ##### With input 100000 #####
+# Name                  ips        average  deviation         median         99th %
+# sort                49.39       20.25 ms     ±4.29%       20.12 ms       24.96 ms
+# lazy_select          1.14      878.75 ms     ±3.60%      869.93 ms      938.22 ms
+
+# Comparison:
+# sort                49.39
+# lazy_select          1.14 - 43.40x slower +858.50 ms
+
+# Memory usage statistics:
+
+# Name           Memory usage
+# sort               15.15 KB
+# lazy_select         3.84 KB - 0.25x memory usage -11.31250 KB
+
+# **All measurements for memory usage were the same**

--- a/benchmarks/lazy_select_vs_sort.exs
+++ b/benchmarks/lazy_select_vs_sort.exs
@@ -4,7 +4,7 @@ Nx.Defn.global_default_options(compiler: EXLA)
 
 key = Nx.Random.key(System.os_time())
 
-inputs_knn = %{
+inputs_k_smallest = %{
   "10" => elem(Nx.Random.shuffle(key, Nx.iota({10})), 0),
   "100" => elem(Nx.Random.shuffle(key, Nx.iota({100})), 0),
   "1000" => elem(Nx.Random.shuffle(key, Nx.iota({1000})), 0),
@@ -23,7 +23,7 @@ Benchee.run(
   },
   time: 10,
   memory_time: 2,
-  inputs: inputs_knn
+  inputs: inputs_k_smallest
 )
 
 

--- a/lib/scholar/lazy_select.ex
+++ b/lib/scholar/lazy_select.ex
@@ -1,0 +1,79 @@
+defmodule Scholar.LazySelect do
+  import Nx.Defn
+
+  deftransform lazy_select(tensor, opts \\ []) do
+    k = opts[:k]
+
+    if Nx.rank(tensor) != 1 do
+      raise ArgumentError, "expected a vector, got a #{inspect(tensor)}"
+    end
+
+    if k >= Nx.size(tensor) do
+      raise ArgumentError, "k must be less than the size of the tensor"
+    end
+
+    len = Nx.size(tensor)
+    selection_len = :math.pow(len, 3 / 4) |> trunc()
+    key = Nx.Random.key(System.system_time())
+    opts = Keyword.put(opts, :selection_len, selection_len)
+    lazy_select_core(tensor, key, opts)
+  end
+
+  defnp lazy_select_core(tensor, key, opts \\ []) do
+    k = opts[:k]
+    selection_len = opts[:selection_len]
+
+    type = Nx.type(tensor)
+    max_val = Nx.Constants.max(type)
+
+    len = Nx.size(tensor)
+    x = Nx.as_type(k * Nx.pow(len, -1 / 4), :s64)
+    len_sqrt = Nx.sqrt(len)
+    low_index = Nx.as_type(Nx.max(0, x - len_sqrt), :s64)
+    high_index = Nx.as_type(Nx.min(selection_len - 1, x + len_sqrt), :s64)
+
+    termination_condition = Nx.u8(0)
+
+    {result, _} =
+      while {res = Nx.tensor(0, type: Nx.type(tensor)),
+             {tensor, key, max_val, termination_condition}},
+            termination_condition != 1 do
+        {candidates, new_key} = Nx.Random.choice(key, tensor, samples: selection_len)
+        candidates = Nx.sort(candidates)
+
+        low = Nx.take(candidates, low_index)
+        high = Nx.take(candidates, high_index)
+
+        low_pos = Nx.sum(low > tensor)
+        high_pos = Nx.sum(high > tensor)
+
+        indices_to_append = tensor >= low and tensor <= high
+
+        {agg_index, agg, _} =
+          while {curr_agg_index = Nx.tensor([0]), agg = Nx.broadcast(max_val, {Kernel.min(4 * selection_len + 2, len)}),
+                 {tensor, indices_to_append, i = 0}},
+                i < len and Nx.reshape(curr_agg_index != 4 * selection_len + 2, {}) do
+            if indices_to_append[i] == Nx.u8(1) do
+              {curr_agg_index + 1, Nx.indexed_put(agg, curr_agg_index, tensor[i]),
+               {tensor, indices_to_append, i + 1}}
+            else
+              {curr_agg_index, agg, {tensor, indices_to_append, i + 1}}
+            end
+          end
+
+        termination_condition =
+          Nx.reshape(low_pos <= k and k <= high_pos and agg_index <= 4 * selection_len + 1, {})
+
+        res =
+          if termination_condition do
+            Nx.sort(agg[0..Kernel.min(4 * selection_len, len - 1)])[k - low_pos]
+          else
+            res
+          end
+
+        {res, {tensor, new_key, max_val, termination_condition}}
+      end
+
+    result
+  end
+end

--- a/lib/scholar/lazy_select.ex
+++ b/lib/scholar/lazy_select.ex
@@ -50,7 +50,8 @@ defmodule Scholar.LazySelect do
         indices_to_append = tensor >= low and tensor <= high
 
         {agg_index, agg, _} =
-          while {curr_agg_index = Nx.tensor([0]), agg = Nx.broadcast(max_val, {Kernel.min(4 * selection_len + 2, len)}),
+          while {curr_agg_index = Nx.tensor([0]),
+                 agg = Nx.broadcast(max_val, {Kernel.min(4 * selection_len + 2, len)}),
                  {tensor, indices_to_append, i = 0}},
                 i < len and Nx.reshape(curr_agg_index != 4 * selection_len + 2, {}) do
             if indices_to_append[i] == Nx.u8(1) do


### PR DESCRIPTION
I implemented `defn` version of lazy_select. This implementation is better, so I'll close the PR in `Nx` in favour of this PR. I also pasted the results of benchmarks of `lazy_select` and `Nx.sort`. `lazy_select` was better only for small tensors. I'm thinking if we want to use it instead of sort for small tensors?