### PR TITLE
Replace second order argsort with permutation inverse

### DIFF
--- a/lib/scholar/neighbors/kd_tree.ex
+++ b/lib/scholar/neighbors/kd_tree.ex
@@ -82,7 +82,7 @@ defmodule Scholar.Neighbors.KDTree do
   end
 
   defnp update_tags(tags, indices, level, levels, size) do
-    pos = Nx.argsort(indices, type: :u32)
+    pos = inverse_permutation(indices)
 
     pivot =
       bounded_segment_begin(tags, levels, size) +
@@ -100,6 +100,14 @@ defmodule Scholar.Neighbors.KDTree do
           tags
         )
       )
+    )
+  end
+
+  defnp inverse_permutation(indices) do
+    Nx.indexed_put(
+      Nx.broadcast(Nx.tensor(0, type: :u32), indices),
+      Nx.new_axis(indices, -1),
+      Nx.iota(Nx.shape(indices))
     )
   end
 

--- a/lib/scholar/neighbors/kd_tree.ex
+++ b/lib/scholar/neighbors/kd_tree.ex
@@ -104,10 +104,13 @@ defmodule Scholar.Neighbors.KDTree do
   end
 
   defnp inverse_permutation(indices) do
+    shape = Nx.shape(indices)
+    type = Nx.type(indices)
+
     Nx.indexed_put(
-      Nx.broadcast(Nx.tensor(0, type: :u32), indices),
+      Nx.broadcast(Nx.tensor(0, type: type), shape),
       Nx.new_axis(indices, -1),
-      Nx.iota(Nx.shape(indices))
+      Nx.iota(shape, type: type)
     )
   end
 


### PR DESCRIPTION
`indices` is a permutation, applying `argsort` to a permutation is the same as permutation inverse and we can compute it in linear time.