### PR TITLE
Random Projection Forest Update

### DIFF
--- a/lib/scholar/neighbors/random_projection_forest.ex
+++ b/lib/scholar/neighbors/random_projection_forest.ex
@@ -253,9 +253,9 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
 
     right_first = Nx.take_along_axis(level_proj, right_indices, axis: 1)
 
-    nodes = Nx.iota({num_nodes}, type: :u32)
     medians_first = (left_first + right_first) / 2
 
+    nodes = Nx.iota({num_nodes}, type: :u32)
     median_mask = width <= nodes and nodes < width + median_offset
     median_pos = Nx.argsort(median_mask, direction: :desc, stable: true, type: :u32)
     level_medians = Nx.take(medians_first, median_pos, axis: 1)

--- a/lib/scholar/neighbors/random_projection_forest.ex
+++ b/lib/scholar/neighbors/random_projection_forest.ex
@@ -48,7 +48,7 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
     num_neighbors: [
       required: true,
       type: :pos_integer,
-      doc: "The number of nearest neighbors ..."
+      doc: "The number of nearest neighbors."
     ],
     min_leaf_size: [
       type: :pos_integer,

--- a/lib/scholar/neighbors/random_projection_forest.ex
+++ b/lib/scholar/neighbors/random_projection_forest.ex
@@ -1,6 +1,6 @@
 defmodule Scholar.Neighbors.RandomProjectionForest do
   @moduledoc """
-  Random Projection Forest.
+  Random Projection Forest for k-Nearest Neighbor Search.
 
   Each tree in a forest is constructed using a divide and conquer approach.
   We start with the entire dataset and at every node we project the data onto a random
@@ -18,25 +18,46 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   """
 
   import Nx.Defn
-  import Scholar.Shared
   require Nx
 
   @derive {Nx.Container,
-           keep: [:depth, :leaf_size, :num_trees],
+           keep: [:num_neighbors, :depth, :leaf_size, :num_trees],
            containers: [:indices, :data, :hyperplanes, :medians]}
-  @enforce_keys [:depth, :leaf_size, :num_trees, :indices, :data, :hyperplanes, :medians]
-  defstruct [:depth, :leaf_size, :num_trees, :indices, :data, :hyperplanes, :medians]
+  @enforce_keys [
+    :num_neighbors,
+    :depth,
+    :leaf_size,
+    :num_trees,
+    :indices,
+    :data,
+    :hyperplanes,
+    :medians
+  ]
+  defstruct [
+    :num_neighbors,
+    :depth,
+    :leaf_size,
+    :num_trees,
+    :indices,
+    :data,
+    :hyperplanes,
+    :medians
+  ]
 
   opts = [
+    num_neighbors: [
+      required: true,
+      type: :pos_integer,
+      doc: "The number of nearest neighbors ..."
+    ],
+    min_leaf_size: [
+      type: :pos_integer,
+      doc: "The minumum number of points in the leaf."
+    ],
     num_trees: [
       required: true,
       type: :pos_integer,
       doc: "The number of trees in the forest."
-    ],
-    min_leaf_size: [
-      required: true,
-      type: :pos_integer,
-      doc: "The minumum number of points in the leaf."
     ],
     key: [
       type: {:custom, Scholar.Options, :key, []},
@@ -59,13 +80,13 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   ## Examples
 
       iex> key = Nx.Random.key(12)
-      iex> tensor = Nx.iota({5, 2})
-      iex> forest = Scholar.Neighbors.RandomProjectionForest.fit(tensor, num_trees: 3, min_leaf_size: 2, key: key)
+      iex> tensor = Nx.iota({5, 3})
+      iex> forest = Scholar.Neighbors.RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 3, key: key)
       iex> forest.indices
       #Nx.Tensor<
         u32[3][5]
         [
-          [0, 1, 2, 3, 4],
+          [4, 3, 2, 1, 0],
           [0, 1, 2, 3, 4],
           [4, 3, 2, 1, 0]
         ]
@@ -81,7 +102,25 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
     end
 
     opts = NimbleOptions.validate!(opts, @opts_schema)
+    num_neighbors = opts[:num_neighbors]
     min_leaf_size = opts[:min_leaf_size]
+
+    min_leaf_size =
+      cond do
+        is_nil(min_leaf_size) ->
+          num_neighbors
+
+        min_leaf_size >= num_neighbors ->
+          min_leaf_size
+
+        true ->
+          raise ArgumentError,
+                """
+                expected min_leaf_size to be at least num_neighbors = #{inspect(num_neighbors)}, \
+                got #{inspect(min_leaf_size)}
+                """
+      end
+
     num_trees = opts[:num_trees]
     key = Keyword.get_lazy(opts, :key, fn -> Nx.Random.key(System.system_time()) end)
     size = Nx.axis_size(tensor, 0)
@@ -100,6 +139,7 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
     {indices, hyperplanes, medians} = fit_n(tensor, key, depth: depth, num_trees: num_trees)
 
     %__MODULE__{
+      num_neighbors: num_neighbors,
       depth: depth,
       leaf_size: leaf_size,
       num_trees: num_trees,
@@ -130,17 +170,16 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   defn fit_n(tensor, key, opts) do
     depth = opts[:depth]
     num_trees = opts[:num_trees]
-    type = to_float_type(tensor)
     {size, dim} = Nx.shape(tensor)
     num_nodes = 2 ** depth - 1
 
     {hyperplanes, _key} =
-      Nx.Random.normal(key, type: type, shape: {num_trees, depth, dim})
+      Nx.Random.normal(key, type: :f64, shape: {num_trees, depth, dim})
 
     {indices, medians, _} =
       while {
               indices = Nx.iota({num_trees, size}, axis: 1, type: :u32),
-              medians = Nx.broadcast(Nx.tensor(:nan, type: type), {num_trees, num_nodes}),
+              medians = Nx.broadcast(Nx.tensor(:nan, type: :f64), {num_trees, num_nodes}),
               {
                 tensor,
                 hyperplanes,
@@ -234,92 +273,103 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   end
 
   @doc """
-  Computes the leaf indices for every point in the input tensor.
-  If the input tensor contains n points, then the result has shape {n, num_trees, leaf_size}.
+  Computes approximate nearest neighbors of query tensor using random projection forest.
+  Returns the neighbor indices and distances from query points.
 
   ## Examples
 
       iex> key = Nx.Random.key(12)
-      iex> tensor = Nx.iota({5, 2})
-      iex> forest = Scholar.Neighbors.RandomProjectionForest.fit(tensor, num_trees: 3, min_leaf_size: 2, key: key)
-      iex> x = Nx.tensor([[3, 4]])
-      iex> Scholar.Neighbors.RandomProjectionForest.predict(forest, x)
+      iex> tensor = Nx.iota({5, 3})
+      iex> forest = Scholar.Neighbors.RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 3, key: key)
+      iex> query = Nx.tensor([[5, 6, 7]])
+      iex> {neighbors, distances} = Scholar.Neighbors.RandomProjectionForest.predict(forest, query)
+      iex> neighbors
       #Nx.Tensor<
-        u32[1][3][3]
+        u32[1][2]
         [
-          [
-            [0, 1, 2],
-            [0, 1, 2],
-            [4, 3, 2]
-          ]
+          [2, 1]
+        ]
+      >
+      iex> distances
+      #Nx.Tensor<
+        f32[1][2]
+        [
+          [3.0, 12.0]
         ]
       >
   """
-  deftransform predict(%__MODULE__{} = forest, x) do
-    if Nx.rank(x) != 2 do
+  deftransform predict(%__MODULE__{} = forest, query) do
+    if Nx.rank(query) != 2 do
       raise ArgumentError,
             """
-            expected input tensor to have shape {num_samples, num_features}, \
-            got tensor with shape: #{inspect(Nx.shape(x))}\
+            expected query tensor to have shape {num_samples, num_features}, \
+            got tensor with shape: #{inspect(Nx.shape(query))}
             """
     end
 
-    if Nx.axis_size(forest.hyperplanes, 2) != Nx.axis_size(x, 1) do
+    if Nx.axis_size(forest.data, 1) != Nx.axis_size(query, 1) do
       raise ArgumentError,
             """
-            expected hyperplanes and input tensor to have the same dimension, \
-            got #{inspect(Nx.axis_size(forest.hyperplanes, 2))} \
-            and #{inspect(Nx.axis_size(x, 1))}
+            expected query tensor to have the same dimension as tensor used to grow the forest, \
+            got #{inspect(Nx.axis_size(forest.data, 1))} \
+            and #{inspect(Nx.axis_size(query, 1))}
             """
     end
 
-    predict_n(forest, x)
+    predict_n(forest, query)
   end
 
-  defn predict_n(forest, x) do
+  defnp predict_n(forest, query) do
+    k = forest.num_neighbors
     num_trees = forest.num_trees
     leaf_size = forest.leaf_size
     indices = forest.indices |> Nx.vectorize(:trees)
-    start_indices = compute_start_indices(forest, x, leaf_size: leaf_size) |> Nx.new_axis(1)
-    size = Nx.axis_size(x, 0)
+    start_indices = compute_start_indices(forest, query) |> Nx.new_axis(1)
+    query_size = Nx.axis_size(query, 0)
 
     pos =
       Nx.iota({1, 1, leaf_size})
-      |> Nx.broadcast({num_trees, size, leaf_size})
+      |> Nx.broadcast({num_trees, query_size, leaf_size})
       |> Nx.vectorize(:trees)
       |> Nx.add(start_indices)
 
-    Nx.take(indices, pos)
-    |> Nx.devectorize()
-    |> Nx.rename(nil)
-    |> Nx.transpose(axes: [1, 0, 2])
+    candidate_indices =
+      Nx.take(indices, pos)
+      |> Nx.devectorize()
+      |> Nx.rename(nil)
+      |> Nx.transpose(axes: [1, 0, 2])
+      |> Nx.reshape({query_size, num_trees * leaf_size})
+
+    find_neighbors(query, forest.data, candidate_indices, num_neighbors: k)
   end
 
-  defn compute_start_indices(forest, x, opts) do
-    leaf_size = opts[:leaf_size]
-    size = Nx.axis_size(x, 0)
+  defnp compute_start_indices(forest, query) do
     depth = forest.depth
+    leaf_size = forest.leaf_size
     num_trees = forest.num_trees
-    hyperplanes = forest.hyperplanes |> Nx.vectorize(:trees)
+    hyperplanes = forest.hyperplanes
     medians = forest.medians |> Nx.vectorize(:trees)
+    size = Nx.axis_size(forest.data, 0)
+    query_size = Nx.axis_size(query, 0)
 
     {start_indices, left?, cell_sizes, _} =
       while {
-              start_indices = Nx.broadcast(Nx.u32(0), {num_trees, size}) |> Nx.vectorize(:trees),
-              _left? = Nx.broadcast(Nx.u8(0), {num_trees, size}) |> Nx.vectorize(:trees),
-              cell_sizes = Nx.broadcast(Nx.u32(size), {num_trees, size}) |> Nx.vectorize(:trees),
+              start_indices =
+                Nx.broadcast(Nx.u32(0), {num_trees, query_size}) |> Nx.vectorize(:trees),
+              _left? = Nx.broadcast(Nx.u8(0), {num_trees, query_size}) |> Nx.vectorize(:trees),
+              cell_sizes =
+                Nx.broadcast(Nx.u32(size), {num_trees, query_size}) |> Nx.vectorize(:trees),
               {
-                x,
+                query,
                 hyperplanes,
                 medians,
                 level = 0,
-                nodes = Nx.broadcast(Nx.u32(0), {num_trees, size}) |> Nx.vectorize(:trees)
+                nodes = Nx.broadcast(Nx.u32(0), {num_trees, query_size}) |> Nx.vectorize(:trees)
               }
             },
             level < depth do
-        h = hyperplanes[level]
+        proj = Nx.dot(hyperplanes[[.., level]], [1], query, [1]) |> Nx.vectorize(:trees)
         median = Nx.take(medians, nodes)
-        proj = Nx.dot(x, h)
         left? = proj <= median
 
         nodes =
@@ -338,18 +388,74 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
           start_indices,
           left?,
           cell_sizes,
-          {x, hyperplanes, medians, level + 1, nodes}
+          {query, hyperplanes, medians, level + 1, nodes}
         }
       end
 
     Nx.select(not left? and cell_sizes < leaf_size, start_indices - 1, start_indices)
   end
 
-  defn left_child(nodes) do
-    2 * nodes + 1
+  defnp left_child(nodes), do: 2 * nodes + 1
+
+  defnp right_child(nodes), do: 2 * nodes + 2
+
+  defnp find_neighbors(query, data, candidate_indices, opts) do
+    k = opts[:num_neighbors]
+    {size, length} = Nx.shape(candidate_indices)
+
+    distances =
+      query
+      |> Nx.new_axis(1)
+      |> Nx.subtract(Nx.take(data, candidate_indices))
+      |> Nx.pow(2)
+      |> Nx.sum(axes: [2])
+
+    distances =
+      if length > 1 do
+        sorted_indices = Nx.argsort(candidate_indices, axis: 1, stable: true)
+        inverse = inverse_permutation(sorted_indices)
+        sorted = Nx.take_along_axis(candidate_indices, sorted_indices, axis: 1)
+
+        duplicate_mask =
+          Nx.concatenate(
+            [
+              Nx.broadcast(0, {size, 1}),
+              Nx.equal(sorted[[.., 0..-2//1]], sorted[[.., 1..-1//1]])
+            ],
+            axis: 1
+          )
+          |> Nx.take_along_axis(inverse, axis: 1)
+
+        Nx.select(duplicate_mask, :infinity, distances)
+      else
+        distances
+      end
+
+    indices = Nx.argsort(distances, axis: 1) |> Nx.slice_along_axis(0, k, axis: 1)
+
+    neighbor_indices =
+      Nx.take(
+        Nx.vectorize(candidate_indices, :samples),
+        Nx.vectorize(indices, :samples)
+      )
+      |> Nx.devectorize()
+      |> Nx.rename(nil)
+
+    neighbor_distances = Nx.take_along_axis(distances, indices, axis: 1)
+
+    {neighbor_indices, neighbor_distances}
   end
 
-  defn right_child(nodes) do
-    2 * nodes + 2
+  defnp inverse_permutation(indices) do
+    {size, length} = Nx.shape(indices)
+    target = Nx.broadcast(Nx.u32(0), {size, length})
+    samples = Nx.iota({size, length, 1}, axis: 0)
+
+    indices =
+      Nx.concatenate([samples, Nx.new_axis(indices, 2)], axis: 2)
+      |> Nx.reshape({size * length, 2})
+
+    updates = Nx.iota({size, length}, axis: 1) |> Nx.reshape({size * length})
+    Nx.indexed_add(target, indices, updates)
   end
 end

--- a/lib/scholar/neighbors/random_projection_forest.ex
+++ b/lib/scholar/neighbors/random_projection_forest.ex
@@ -18,6 +18,7 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   """
 
   import Nx.Defn
+  import Scholar.Shared
   require Nx
 
   @derive {Nx.Container,
@@ -80,13 +81,13 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   ## Examples
 
       iex> key = Nx.Random.key(12)
-      iex> tensor = Nx.iota({5, 3})
+      iex> tensor = Nx.iota({5, 2})
       iex> forest = Scholar.Neighbors.RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 3, key: key)
       iex> forest.indices
       #Nx.Tensor<
         u32[3][5]
         [
-          [4, 3, 2, 1, 0],
+          [0, 1, 2, 3, 4],
           [0, 1, 2, 3, 4],
           [4, 3, 2, 1, 0]
         ]
@@ -170,16 +171,17 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   defn fit_n(tensor, key, opts) do
     depth = opts[:depth]
     num_trees = opts[:num_trees]
+    type = to_float_type(tensor)
     {size, dim} = Nx.shape(tensor)
     num_nodes = 2 ** depth - 1
 
     {hyperplanes, _key} =
-      Nx.Random.normal(key, type: :f64, shape: {num_trees, depth, dim})
+      Nx.Random.normal(key, type: type, shape: {num_trees, depth, dim})
 
     {indices, medians, _} =
       while {
               indices = Nx.iota({num_trees, size}, axis: 1, type: :u32),
-              medians = Nx.broadcast(Nx.tensor(:nan, type: :f64), {num_trees, num_nodes}),
+              medians = Nx.broadcast(Nx.tensor(:nan, type: type), {num_trees, num_nodes}),
               {
                 tensor,
                 hyperplanes,
@@ -279,22 +281,22 @@ defmodule Scholar.Neighbors.RandomProjectionForest do
   ## Examples
 
       iex> key = Nx.Random.key(12)
-      iex> tensor = Nx.iota({5, 3})
+      iex> tensor = Nx.iota({5, 2})
       iex> forest = Scholar.Neighbors.RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 3, key: key)
-      iex> query = Nx.tensor([[5, 6, 7]])
+      iex> query = Nx.tensor([[3, 4]])
       iex> {neighbors, distances} = Scholar.Neighbors.RandomProjectionForest.predict(forest, query)
       iex> neighbors
       #Nx.Tensor<
         u32[1][2]
         [
-          [2, 1]
+          [1, 2]
         ]
       >
       iex> distances
       #Nx.Tensor<
         f32[1][2]
         [
-          [3.0, 12.0]
+          [2.0, 2.0]
         ]
       >
   """

--- a/test/scholar/neighbors/random_projection_forest_test.exs
+++ b/test/scholar/neighbors/random_projection_forest_test.exs
@@ -36,11 +36,6 @@ defmodule Scholar.Neighbors.RandomProjectionForestTest do
     end
   end
 
-  defp x do
-    key = Nx.Random.key(12)
-    Nx.Random.uniform(key, shape: {1000, 10}) |> elem(0)
-  end
-
   describe "predict" do
     test "shape" do
       tensor = example()
@@ -57,7 +52,25 @@ defmodule Scholar.Neighbors.RandomProjectionForestTest do
 
     test "every point is its own neighbor when num_neighbors is 1" do
       key = Nx.Random.key(12)
-      tensor = x()
+      {tensor, key} = Nx.Random.uniform(key, shape: {1000, 10})
+      size = Nx.axis_size(tensor, 0)
+
+      forest =
+        RandomProjectionForest.fit(tensor,
+          num_neighbors: 1,
+          num_trees: 1,
+          min_leaf_size: 1,
+          key: key
+        )
+
+      {neighbors, distances} = RandomProjectionForest.predict(forest, tensor)
+      assert Nx.flatten(neighbors) == Nx.iota({size}, type: :u32)
+      assert Nx.flatten(distances) == Nx.broadcast(0.0, {size})
+    end
+
+    test "every point is its own neighbor when num_neighbors is 1 and size is power of two" do
+      key = Nx.Random.key(12)
+      {tensor, key} = Nx.Random.uniform(key, shape: {1024, 10})
       size = Nx.axis_size(tensor, 0)
 
       forest =

--- a/test/scholar/neighbors/random_projection_forest_test.exs
+++ b/test/scholar/neighbors/random_projection_forest_test.exs
@@ -21,7 +21,11 @@ defmodule Scholar.Neighbors.RandomProjectionForestTest do
   describe "fit" do
     test "shape" do
       tensor = example()
-      forest = RandomProjectionForest.fit(tensor, num_trees: 4, min_leaf_size: 3)
+
+      forest =
+        RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 4, min_leaf_size: 3)
+
+      assert forest.num_neighbors == 2
       assert forest.depth == 1
       assert forest.leaf_size == 5
       assert forest.num_trees == 4
@@ -34,23 +38,37 @@ defmodule Scholar.Neighbors.RandomProjectionForestTest do
 
   defp x do
     key = Nx.Random.key(12)
-    Nx.Random.uniform(key, shape: {1024, 10}) |> elem(0)
+    Nx.Random.uniform(key, shape: {1000, 10}) |> elem(0)
   end
 
   describe "predict" do
     test "shape" do
       tensor = example()
-      forest = RandomProjectionForest.fit(tensor, num_trees: 4, min_leaf_size: 3)
-      leaf_indices = RandomProjectionForest.predict(forest, Nx.tensor([[20, 30], [30, 50]]))
-      assert Nx.shape(leaf_indices) == {2, forest.num_trees, forest.leaf_size}
+
+      forest =
+        RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 4, min_leaf_size: 3)
+
+      {neighbor_indices, neighbor_distances} = RandomProjectionForest.predict(forest, Nx.tensor([[20, 30], [30, 50]]))
+      assert Nx.shape(neighbor_indices) == {2, 2}
+      assert Nx.shape(neighbor_distances) == {2, 2}
     end
 
-    test "every point is its own leaf when leaf_size is 1" do
+    test "every point is its own neighbor when num_neighbors is 1" do
       key = Nx.Random.key(12)
       tensor = x()
-      forest = RandomProjectionForest.fit(tensor, num_trees: 1, min_leaf_size: 1, key: key)
-      leaf_indices = RandomProjectionForest.predict(forest, tensor)
-      assert Nx.flatten(leaf_indices) == Nx.iota({Nx.axis_size(tensor, 0)}, type: :u32)
+      size = Nx.axis_size(tensor, 0)
+
+      forest =
+        RandomProjectionForest.fit(tensor,
+          num_neighbors: 1,
+          num_trees: 1,
+          min_leaf_size: 1,
+          key: key
+        )
+
+      {neighbors, distances} = RandomProjectionForest.predict(forest, tensor)
+      assert Nx.flatten(neighbors) == Nx.iota({size}, type: :u32)
+      assert Nx.flatten(distances) == Nx.broadcast(0.0, {size})
     end
   end
 end

--- a/test/scholar/neighbors/random_projection_forest_test.exs
+++ b/test/scholar/neighbors/random_projection_forest_test.exs
@@ -48,7 +48,9 @@ defmodule Scholar.Neighbors.RandomProjectionForestTest do
       forest =
         RandomProjectionForest.fit(tensor, num_neighbors: 2, num_trees: 4, min_leaf_size: 3)
 
-      {neighbor_indices, neighbor_distances} = RandomProjectionForest.predict(forest, Nx.tensor([[20, 30], [30, 50]]))
+      {neighbor_indices, neighbor_distances} =
+        RandomProjectionForest.predict(forest, Nx.tensor([[20, 30], [30, 50]]))
+
       assert Nx.shape(neighbor_indices) == {2, 2}
       assert Nx.shape(neighbor_distances) == {2, 2}
     end


### PR DESCRIPTION
Changelog:
- Fixed the bug inside `predict/2` that assumed that query is of the same size as tensor used to grow the forest.
- Predict now returns the indices of (approximate) k-nearest neigbors as well as distances from the query points.
- ~~Hyperplanes and medians are now `f64`.~~
- Incorporated some feedback from #215 I didn't manage to before the pull request got closed. E.g. `left_child` and `right_child` are private now.
- Fixes https://github.com/elixir-nx/scholar/issues/230.

One thing I am still not sure about. `num_neighbors` is passed as an argument to `fit/2`. I prefer it like this, but it also makes sense to pass it as an argument to `predict/2`. There is also a small inconsistency with the option name used for the number of neighbors: [KNearestNeighbors uses num_neighbors](https://github.com/elixir-nx/scholar/blob/58ee5e32e96e5830c7d0da553786879ad4aa2a4f/lib/scholar/neighbors/k_nearest_neighbors.ex#L20), while [KDTree uses k](https://github.com/elixir-nx/scholar/blob/58ee5e32e96e5830c7d0da553786879ad4aa2a4f/lib/scholar/neighbors/kd_tree.ex#L28).