### PR TITLE
Add Mean Pinball Loss function.

### DIFF
--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -534,7 +534,7 @@ defmodule Scholar.Metrics.Regression do
         {:or,
          [
            {:custom, Scholar.Options, :weights, []},
-           {:custom, Scholar.Options, :multi_weights, []}           
+           {:custom, Scholar.Options, :multi_weights, []}
          ]},
       doc: """
       The weights for each observation. If not provided,
@@ -542,12 +542,12 @@ defmodule Scholar.Metrics.Regression do
       """
     ],
     multioutput: [
-      type: {:or,
-             [
-               {:custom, Scholar.Options, :weights, []},
-               {:in, [:raw_values, :uniform_average]}
-             ]
-      },
+      type:
+        {:or,
+         [
+           {:custom, Scholar.Options, :weights, []},
+           {:in, [:raw_values, :uniform_average]}
+         ]},
       default: :uniform_average,
       doc: """
       Defines aggregating of multiple output values.
@@ -559,14 +559,15 @@ defmodule Scholar.Metrics.Regression do
 
         `:uniform_average` :
             Errors of all outputs are averaged with uniform weight.
-      
+
       The weights for each observation. If not provided,
       all observations are assigned equal weight.
-      """      
+      """
     ]
   ]
+
   @mean_pinball_loss_schema NimbleOptions.new!(mean_pinball_loss_opts)
-  
+
   @doc ~S"""
   Calculates the mean pinball loss to evaluate predictive performance of quantile regression models.
 
@@ -598,6 +599,7 @@ defmodule Scholar.Metrics.Regression do
   deftransform mean_pinball_loss(y_true, y_pred, opts \\ []) do
     mean_pinball_loss_n(y_true, y_pred, NimbleOptions.validate!(opts, @mean_pinball_loss_schema))
   end
+
   defnp mean_pinball_loss_n(y_true, y_pred, opts) do
     assert_same_shape!(y_true, y_pred)
     alpha = opts[:alpha]
@@ -612,20 +614,25 @@ defmodule Scholar.Metrics.Regression do
     # mimics the sklearn behavior
     case opts[:multioutput] do
       # raw_values returns plain output errors. One value per channel.
-      :raw_values -> output_errors
+      :raw_values ->
+        output_errors
+
       # uniform_average returns the mean of the above. Note how they are averaged.
       :uniform_average ->
         output_errors
         |> Nx.mean()
+
       # pass `:multioutput` as sample weights to average the error of each output
       multi_output_weights ->
-        handle_sample_weights(output_errors, [sample_weights: multi_output_weights])
+        handle_sample_weights(output_errors, sample_weights: multi_output_weights)
     end
   end
 
   defnp handle_sample_weights(loss, opts, mean_opts \\ []) do
     case opts[:sample_weights] do
-      nil -> Nx.mean(loss, mean_opts)
+      nil ->
+        Nx.mean(loss, mean_opts)
+
       weights ->
         Nx.weighted_mean(loss, weights, mean_opts)
     end

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -559,10 +559,13 @@ defmodule Scholar.Metrics.Regression do
     output_errors = handle_sample_weights(loss, opts, axes: [0])
     # mimics the sklearn behavior
     case opts[:multioutput] do
+      # raw_values returns plain output errors. One value per channel.
       :raw_values -> output_errors
+      # uniform_average returns the mean of the above. Note how they are averaged.
       :uniform_average ->
         output_errors
         |> Nx.mean()
+      # every other case, just take the mean without any axes nor weight.
       _ -> handle_sample_weights(loss, opts)
     end
   end

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -548,7 +548,15 @@ defmodule Scholar.Metrics.Regression do
     diff = y_true - y_pred
     sign = diff >= 0
     loss = alpha * sign * diff - (1 - alpha) * (1 - sign) * diff
-    Nx.mean(loss)
+
+    handle_sample_weights(loss, opts)
+  end
+
+  defnp handle_sample_weights(loss, opts) do
+    case opts[:sample_weights] do
+      nil -> Nx.mean(loss)
+      weights -> Nx.weighted_mean(loss, weights)
+    end
   end
 
   defnp check_shape(y_true, y_pred) do

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -533,13 +533,13 @@ defmodule Scholar.Metrics.Regression do
 
       iex> y_true = Nx.tensor([1, 2, 3])
       iex> y_pred = Nx.tensor([2, 3, 4])
-      iex> Scholar.Metrics.Regression.mean_pinball_loss(y_true, y_pred, 0.5)
+      iex> Scholar.Metrics.Regression.mean_pinball_loss(y_true, y_pred)
       #Nx.Tensor<
         f32
         0.5
       >
   """
-  defn mean_pinball_loss(y_true, y_pred, opts \\ []) do
+  defn mean_pinball_loss(y_true, y_pred, opts \\ [alpha: 0.5]) do
     check_shape(y_true, y_pred)
     alpha = opts[:alpha]
 

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -595,8 +595,10 @@ defmodule Scholar.Metrics.Regression do
         [0.5, 0.3333333432674408, 0.0, 0.0]
       >
   """
-  defn mean_pinball_loss(y_true, y_pred, opts \\ []) do
-    opts = validate_opts(opts)
+  deftransform mean_pinball_loss(y_true, y_pred, opts \\ []) do
+    mean_pinball_loss_n(y_true, y_pred, NimbleOptions.validate!(opts, @mean_pinball_loss_schema))
+  end
+  defnp mean_pinball_loss_n(y_true, y_pred, opts \\ []) do
     assert_same_shape!(y_true, y_pred)
     alpha = opts[:alpha]
 

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -615,15 +615,12 @@ defmodule Scholar.Metrics.Regression do
       :uniform_average ->
         output_errors
         |> Nx.mean()
-      # every other case, just take the mean without any axes nor weight.
-      _ -> handle_sample_weights(loss, opts)
+      # pass `:multioutput` as sample weights to average the error of each output
+      multi_output_weights ->
+        handle_sample_weights(output_errors, [sample_weights: multi_output_weights])
     end
   end
 
-  deftransform validate_opts(opts) do
-    NimbleOptions.validate!(opts, @mean_pinball_loss_schema)
-  end
-  
   defnp handle_sample_weights(loss, opts, mean_opts \\ []) do
     case opts[:sample_weights] do
       nil -> Nx.mean(loss, mean_opts)

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -544,16 +544,10 @@ defmodule Scholar.Metrics.Regression do
 
     # Formula adapted from sklearn:
     # https://github.com/scikit-learn/scikit-learn/blob/128e40ed593c57e8b9e57a4109928d58fa8bf359/sklearn/metrics/_regression.py#L299
-    diff = Nx.subtract(y_true, y_pred)
-    sign = Nx.greater_equal(diff, 0)
-    subtracted_sign = Nx.subtract(1, sign)
-    
-    Nx.subtract(
-      Nx.multiply(alpha, sign)
-      |> Nx.multiply(diff),
-      Nx.multiply(1 - alpha, subtracted_sign)
-      |> Nx.multiply(diff))
-    |> Nx.mean()
+    diff = y_true - y_pred
+    sign = diff >= 0
+    loss = alpha * sign * diff - (1 - alpha) * (1 - sign) * diff
+    Nx.mean(loss)
   end
 
   defnp check_shape(y_true, y_pred) do

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -598,7 +598,7 @@ defmodule Scholar.Metrics.Regression do
   deftransform mean_pinball_loss(y_true, y_pred, opts \\ []) do
     mean_pinball_loss_n(y_true, y_pred, NimbleOptions.validate!(opts, @mean_pinball_loss_schema))
   end
-  defnp mean_pinball_loss_n(y_true, y_pred, opts \\ []) do
+  defnp mean_pinball_loss_n(y_true, y_pred, opts) do
     assert_same_shape!(y_true, y_pred)
     alpha = opts[:alpha]
 

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -539,8 +539,9 @@ defmodule Scholar.Metrics.Regression do
         0.5
       >
   """
-  defn mean_pinball_loss(y_true, y_pred, alpha \\ 0.5) do
+  defn mean_pinball_loss(y_true, y_pred, opts \\ []) do
     check_shape(y_true, y_pred)
+    alpha = opts[:alpha]
 
     # Formula adapted from sklearn:
     # https://github.com/scikit-learn/scikit-learn/blob/128e40ed593c57e8b9e57a4109928d58fa8bf359/sklearn/metrics/_regression.py#L299

--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -541,6 +541,9 @@ defmodule Scholar.Metrics.Regression do
   """
   defn mean_pinball_loss(y_true, y_pred, alpha \\ 0.5) do
     check_shape(y_true, y_pred)
+
+    # Formula adapted from sklearn:
+    # https://github.com/scikit-learn/scikit-learn/blob/128e40ed593c57e8b9e57a4109928d58fa8bf359/sklearn/metrics/_regression.py#L299
     diff = Nx.subtract(y_true, y_pred)
     sign = Nx.greater_equal(diff, 0)
     subtracted_sign = Nx.subtract(1, sign)

--- a/lib/scholar/options.ex
+++ b/lib/scholar/options.ex
@@ -85,11 +85,10 @@ defmodule Scholar.Options do
   
   def multi_weights(weights) do
     if is_nil(weights) or
-         (Nx.is_tensor(weights) and Nx.rank(weights) > 0) or
-         (is_list(weights) and Enum.all?(weights, &is_number/1)) do
+         (Nx.is_tensor(weights) and Nx.rank(weights) > 1) do
       {:ok, weights}
     else
-      {:error, "expected weights to be a flat tensor or a flat list, got: #{inspect(weights)}"}
+      {:error, "expected weights to be a tensor with rank greater than 1, got: #{inspect(weights)}"}
     end
   end
 

--- a/lib/scholar/options.ex
+++ b/lib/scholar/options.ex
@@ -82,6 +82,16 @@ defmodule Scholar.Options do
       {:error, "expected weights to be a flat tensor or a flat list, got: #{inspect(weights)}"}
     end
   end
+  
+  def multi_weights(weights) do
+    if is_nil(weights) or
+         (Nx.is_tensor(weights) and Nx.rank(weights) > 0) or
+         (is_list(weights) and Enum.all?(weights, &is_number/1)) do
+      {:ok, weights}
+    else
+      {:error, "expected weights to be a flat tensor or a flat list, got: #{inspect(weights)}"}
+    end
+  end
 
   def key(key) do
     if Nx.is_tensor(key) and Nx.type(key) == {:u, 32} and Nx.shape(key) == {2} do

--- a/lib/scholar/options.ex
+++ b/lib/scholar/options.ex
@@ -82,13 +82,14 @@ defmodule Scholar.Options do
       {:error, "expected weights to be a flat tensor or a flat list, got: #{inspect(weights)}"}
     end
   end
-  
+
   def multi_weights(weights) do
     if is_nil(weights) or
          (Nx.is_tensor(weights) and Nx.rank(weights) > 1) do
       {:ok, weights}
     else
-      {:error, "expected weights to be a tensor with rank greater than 1, got: #{inspect(weights)}"}
+      {:error,
+       "expected weights to be a tensor with rank greater than 1, got: #{inspect(weights)}"}
     end
   end
 

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -66,4 +66,17 @@ defmodule Scholar.Metrics.RegressionTest do
       assert Nx.equal(d2, r2)
     end
   end
+  
+  describe "mean_pinball_loss/3" do
+    test "mean_pinball_loss cases from sklearn" do
+      y_true = Nx.linspace(1, 50, n: 50)
+      y_pred = Nx.add(y_true, 1)
+      y_pred_2 = Nx.add(y_true, -1)
+
+      assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.5)
+      assert Regression.mean_pinball_loss(y_true, y_pred_2) == Nx.tensor(0.5)
+      assert Regression.mean_pinball_loss(y_true, y_pred, 0.4) == Nx.tensor(0.6)            
+      assert Regression.mean_pinball_loss(y_true, y_pred_2, 0.4) == Nx.tensor(0.4)
+    end
+  end
 end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -81,5 +81,20 @@ defmodule Scholar.Metrics.RegressionTest do
       assert Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.4) == Nx.tensor(0.6)            
       assert Regression.mean_pinball_loss(y_true, y_pred_2, alpha: 0.4) == Nx.tensor(0.4)
     end
+
+    test "mean_pinball_loss with sample weight" do
+      y_true = Nx.tensor([1, 2, 3, 4, 5, 6])
+      y_pred = Nx.tensor([2, 3, 4, 6, 7, 8])
+      sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5])
+      wrong_sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5, 1, 1, 1])      
+
+      assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.75)
+      assert Regression.mean_pinball_loss(
+        y_true, y_pred, alpha: 0.5, sample_weights: sample_weights) == Nx.tensor(0.625)
+      assert_raise ArgumentError, fn ->
+        Regression.mean_pinball_loss(y_true, y_pred,
+          alpha: 0.5, sample_weights: wrong_sample_weights)
+      end
+    end
   end
 end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -106,30 +106,26 @@ defmodule Scholar.Metrics.RegressionTest do
       expected_raw_values_weighted_tensor = Nx.tensor([0.5, 0.4, 0.0 , 0.0])
 
       mpbl = Regression.mean_pinball_loss(y_true, y_pred)
-      assert almost_equal(mpbl, expected_error)
+      assert_all_close(mpbl, expected_error)
       ## this assertion yields false due to precision error
       mpbl = Regression.mean_pinball_loss(
                y_true, y_pred, alpha: 0.5, multioutput: :uniform_average)
-      assert almost_equal(mpbl, expected_error)
+      assert_all_close(mpbl, expected_error)
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
         alpha: 0.5, multioutput: :raw_values)
-      assert almost_equal(mpbl, expected_raw_values_tensor)
+      assert_all_close(mpbl, expected_raw_values_tensor)
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
         alpha: 0.5, sample_weights: sample_weight,  multioutput: :raw_values)
-      assert almost_equal(mpbl, expected_raw_values_weighted_tensor)
+      assert_all_close(mpbl, expected_raw_values_weighted_tensor)
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
         alpha: 0.5, sample_weights: sample_weight, multioutput: :uniform_average)
-      assert almost_equal(mpbl, Nx.tensor(0.225))
+      assert_all_close(mpbl, Nx.tensor(0.225))
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
         alpha: 0.5, multioutput: Nx.tensor([1, 2, 3, 4]))
-      assert almost_equal(mpbl, Nx.tensor(0.1166666))
+      assert_all_close(mpbl, Nx.tensor(0.1166666))
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
         alpha: 0.5, multioutput: nil)
-      assert almost_equal(mpbl, expected_error)
+      assert_all_close(mpbl, expected_error)
     end
-  end
-
-  defp almost_equal(tensor1, tensor2, tolerance \\ 0.0001) do
-    Nx.abs(Nx.subtract(tensor1, tensor2)) <= Nx.tensor(tolerance)
   end
 end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -101,16 +101,16 @@ defmodule Scholar.Metrics.RegressionTest do
       y_true = Nx.tensor([[1, 0, 0, 1], [0, 1, 1, 1], [1, 1, 0, 1]])
       y_pred = Nx.tensor([[0, 0, 0, 1], [1, 0, 1, 1], [0, 0, 0, 1]])
       sample_weight = Nx.tensor([[0.5, 0.5, 0.5, 1.5], [1.5, 0.5, 1.5, 1.5], [1.5, 1.5, 1.5, 1.5]])
-      expected_error = (1 + 2 / 3) / 8
+      expected_error = Nx.tensor((1 + 2 / 3) / 8)
       expected_raw_values_tensor = Nx.tensor([0.5, 0.33333333, 0.0, 0.0])
       expected_raw_values_weighted_tensor = Nx.tensor([0.5, 0.4, 0.0 , 0.0])
 
       mpbl = Regression.mean_pinball_loss(y_true, y_pred)
-      assert almost_equal(mpbl, Nx.tensor(expected_error))
+      assert almost_equal(mpbl, expected_error)
       ## this assertion yields false due to precision error
       mpbl = Regression.mean_pinball_loss(
                y_true, y_pred, alpha: 0.5, multioutput: :uniform_average)
-      assert almost_equal(mpbl, Nx.tensor(expected_error))
+      assert almost_equal(mpbl, expected_error)
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
         alpha: 0.5, multioutput: :raw_values)
       assert almost_equal(mpbl, expected_raw_values_tensor)
@@ -121,8 +121,11 @@ defmodule Scholar.Metrics.RegressionTest do
         alpha: 0.5, sample_weights: sample_weight, multioutput: :uniform_average)
       assert almost_equal(mpbl, Nx.tensor(0.225))
       mpbl = Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, multioutput: Nx.tensor([1, 2, 3]))
-      assert almost_equal(mpbl, expected_raw_values_weighted_tensor)
+        alpha: 0.5, multioutput: Nx.tensor([1, 2, 3, 4]))
+      assert almost_equal(mpbl, Nx.tensor(0.1166666))
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, multioutput: nil)
+      assert almost_equal(mpbl, expected_error)
     end
   end
 

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -69,6 +69,9 @@ defmodule Scholar.Metrics.RegressionTest do
   
   describe "mean_pinball_loss/3" do
     test "mean_pinball_loss cases from sklearn" do
+      # Test cases copied from sklearn:
+      # https://github.com/scikit-learn/scikit-learn/blob/128e40ed593c57e8b9e57a4109928d58fa8bf359/sklearn/metrics/tests/test_regression.py#L49      
+
       y_true = Nx.linspace(1, 50, n: 50)
       y_pred = Nx.add(y_true, 1)
       y_pred_2 = Nx.add(y_true, -1)

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -96,5 +96,18 @@ defmodule Scholar.Metrics.RegressionTest do
           alpha: 0.5, sample_weights: wrong_sample_weights)
       end
     end
+
+    test "mean_pinball_loss with multioutput" do
+      y_true = Nx.tensor([[1, 0, 0, 1], [0, 1, 1, 1], [1, 1, 0, 1]])
+      y_pred = Nx.tensor([[0, 0, 0, 1], [1, 0, 1, 1], [0, 0, 0, 1]])
+      expected_error = (1 + 2 / 3) / 8
+      expected_raw_values_tensor = Nx.tensor([0.5, 0.33333333, 0.0, 0.0])
+
+      assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(expected_error)
+      assert Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, multioutput: :uniform_average) == Nx.tensor(expected_error)      
+      assert Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, multioutput: :raw_values) == expected_raw_values_tensor
+    end    
   end
 end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -66,7 +66,7 @@ defmodule Scholar.Metrics.RegressionTest do
       assert Nx.equal(d2, r2)
     end
   end
-  
+
   describe "mean_pinball_loss/3" do
     test "mean_pinball_loss cases from sklearn" do
       # Test cases copied from sklearn:
@@ -78,7 +78,7 @@ defmodule Scholar.Metrics.RegressionTest do
 
       assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.5)
       assert Regression.mean_pinball_loss(y_true, y_pred_2) == Nx.tensor(0.5)
-      assert Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.4) == Nx.tensor(0.6)            
+      assert Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.4) == Nx.tensor(0.6)
       assert Regression.mean_pinball_loss(y_true, y_pred_2, alpha: 0.4) == Nx.tensor(0.4)
     end
 
@@ -86,45 +86,77 @@ defmodule Scholar.Metrics.RegressionTest do
       y_true = Nx.tensor([1, 2, 3, 4, 5, 6])
       y_pred = Nx.tensor([2, 3, 4, 6, 7, 8])
       sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5])
-      wrong_sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5, 1, 1, 1])      
+      wrong_sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5, 1, 1, 1])
 
       assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.75)
+
       assert Regression.mean_pinball_loss(
-        y_true, y_pred, alpha: 0.5, sample_weights: sample_weights) == Nx.tensor(0.625)
+               y_true,
+               y_pred,
+               alpha: 0.5,
+               sample_weights: sample_weights
+             ) == Nx.tensor(0.625)
+
       assert_raise ArgumentError, fn ->
         Regression.mean_pinball_loss(y_true, y_pred,
-          alpha: 0.5, sample_weights: wrong_sample_weights)
+          alpha: 0.5,
+          sample_weights: wrong_sample_weights
+        )
       end
     end
 
     test "mean_pinball_loss with multioutput" do
       y_true = Nx.tensor([[1, 0, 0, 1], [0, 1, 1, 1], [1, 1, 0, 1]])
       y_pred = Nx.tensor([[0, 0, 0, 1], [1, 0, 1, 1], [0, 0, 0, 1]])
-      sample_weight = Nx.tensor([[0.5, 0.5, 0.5, 1.5], [1.5, 0.5, 1.5, 1.5], [1.5, 1.5, 1.5, 1.5]])
+
+      sample_weight =
+        Nx.tensor([[0.5, 0.5, 0.5, 1.5], [1.5, 0.5, 1.5, 1.5], [1.5, 1.5, 1.5, 1.5]])
+
       expected_error = Nx.tensor((1 + 2 / 3) / 8)
       expected_raw_values_tensor = Nx.tensor([0.5, 0.33333333, 0.0, 0.0])
-      expected_raw_values_weighted_tensor = Nx.tensor([0.5, 0.4, 0.0 , 0.0])
+      expected_raw_values_weighted_tensor = Nx.tensor([0.5, 0.4, 0.0, 0.0])
 
       mpbl = Regression.mean_pinball_loss(y_true, y_pred)
       assert_all_close(mpbl, expected_error)
       ## this assertion yields false due to precision error
-      mpbl = Regression.mean_pinball_loss(
-               y_true, y_pred, alpha: 0.5, multioutput: :uniform_average)
+      mpbl =
+        Regression.mean_pinball_loss(
+          y_true,
+          y_pred,
+          alpha: 0.5,
+          multioutput: :uniform_average
+        )
+
       assert_all_close(mpbl, expected_error)
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, multioutput: :raw_values)
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.5, multioutput: :raw_values)
       assert_all_close(mpbl, expected_raw_values_tensor)
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, sample_weights: sample_weight,  multioutput: :raw_values)
+
+      mpbl =
+        Regression.mean_pinball_loss(y_true, y_pred,
+          alpha: 0.5,
+          sample_weights: sample_weight,
+          multioutput: :raw_values
+        )
+
       assert_all_close(mpbl, expected_raw_values_weighted_tensor)
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, sample_weights: sample_weight, multioutput: :uniform_average)
+
+      mpbl =
+        Regression.mean_pinball_loss(y_true, y_pred,
+          alpha: 0.5,
+          sample_weights: sample_weight,
+          multioutput: :uniform_average
+        )
+
       assert_all_close(mpbl, Nx.tensor(0.225))
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, multioutput: Nx.tensor([1, 2, 3, 4]))
+
+      mpbl =
+        Regression.mean_pinball_loss(y_true, y_pred,
+          alpha: 0.5,
+          multioutput: Nx.tensor([1, 2, 3, 4])
+        )
+
       assert_all_close(mpbl, Nx.tensor(0.1166666))
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, multioutput: nil)
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.5, multioutput: nil)
       assert_all_close(mpbl, expected_error)
     end
   end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -90,10 +90,10 @@ defmodule Scholar.Metrics.RegressionTest do
 
       assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.75)
       assert Regression.mean_pinball_loss(
-        y_true, y_pred, alpha: 0.5, sample_weight: sample_weights) == Nx.tensor(0.625)
+        y_true, y_pred, alpha: 0.5, sample_weights: sample_weights) == Nx.tensor(0.625)
       assert_raise ArgumentError, fn ->
         Regression.mean_pinball_loss(y_true, y_pred,
-          alpha: 0.5, sample_weight: wrong_sample_weights)
+          alpha: 0.5, sample_weights: wrong_sample_weights)
       end
     end
 
@@ -105,18 +105,28 @@ defmodule Scholar.Metrics.RegressionTest do
       expected_raw_values_tensor = Nx.tensor([0.5, 0.33333333, 0.0, 0.0])
       expected_raw_values_weighted_tensor = Nx.tensor([0.5, 0.4, 0.0 , 0.0])
 
-      assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(expected_error)
-      ## this assertion yields false due to precission error
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.5, multioutput: :uniform_average)
-      assert  Nx.abs(Nx.subtract(mpbl, Nx.tensor(expected_error))) <= Nx.tensor(0.0001)
-      assert Regression.mean_pinball_loss(y_true, y_pred,
-        alpha: 0.5, multioutput: :raw_values) == expected_raw_values_tensor
-      assert Regression.mean_pinball_loss(
-        y_true, y_pred, alpha: 0.5,
-        sample_weight: sample_weight,  multioutput: :raw_values) == expected_raw_values_weighted_tensor
-      assert Regression.mean_pinball_loss(
-        y_true, y_pred, alpha: 0.5,
-        sample_weight: sample_weight, multioutput: :uniform_average) == Nx.tensor(0.225)
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred)
+      assert almost_equal(mpbl, Nx.tensor(expected_error))
+      ## this assertion yields false due to precision error
+      mpbl = Regression.mean_pinball_loss(
+               y_true, y_pred, alpha: 0.5, multioutput: :uniform_average)
+      assert almost_equal(mpbl, Nx.tensor(expected_error))
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, multioutput: :raw_values)
+      assert almost_equal(mpbl, expected_raw_values_tensor)
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, sample_weights: sample_weight,  multioutput: :raw_values)
+      assert almost_equal(mpbl, expected_raw_values_weighted_tensor)
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, sample_weights: sample_weight, multioutput: :uniform_average)
+      assert almost_equal(mpbl, Nx.tensor(0.225))
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred,
+        alpha: 0.5, multioutput: Nx.tensor([1, 2, 3]))
+      assert almost_equal(mpbl, expected_raw_values_weighted_tensor)
     end
+  end
+
+  defp almost_equal(tensor1, tensor2, tolerance \\ 0.0001) do
+    Nx.abs(Nx.subtract(tensor1, tensor2)) <= Nx.tensor(tolerance)
   end
 end

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -78,8 +78,8 @@ defmodule Scholar.Metrics.RegressionTest do
 
       assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.5)
       assert Regression.mean_pinball_loss(y_true, y_pred_2) == Nx.tensor(0.5)
-      assert Regression.mean_pinball_loss(y_true, y_pred, 0.4) == Nx.tensor(0.6)            
-      assert Regression.mean_pinball_loss(y_true, y_pred_2, 0.4) == Nx.tensor(0.4)
+      assert Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.4) == Nx.tensor(0.6)            
+      assert Regression.mean_pinball_loss(y_true, y_pred_2, alpha: 0.4) == Nx.tensor(0.4)
     end
   end
 end


### PR DESCRIPTION
The Mean Pinball Loss function for evaluation of prediction performance of regression models.
Listed in the functions to add[ in this issue](https://github.com/elixir-nx/scholar/issues/122).

I've adapted the implementation from `sklearn` and the relevant of that library are linked in the code, to give credit and serve as reference.