### PR TITLE
Unify weight handling and refactor linear models' helper functions

### DIFF
--- a/lib/scholar/linear/bayesian_ridge_regression.ex
+++ b/lib/scholar/linear/bayesian_ridge_regression.ex
@@ -232,13 +232,9 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
       ] ++
         opts
 
-    {sample_weights, opts} = Keyword.pop(opts, :sample_weights, 1.0)
     x_type = to_float_type(x)
 
-    sample_weights =
-      if Nx.is_tensor(sample_weights),
-        do: Nx.as_type(sample_weights, x_type),
-        else: Nx.tensor(sample_weights, type: x_type)
+    sample_weights = LinearHelpers.build_sample_weights(x, opts)
 
     # handle vector types
     # handle default alpha value, add eps to avoid division by 0

--- a/lib/scholar/linear/bayesian_ridge_regression.ex
+++ b/lib/scholar/linear/bayesian_ridge_regression.ex
@@ -96,13 +96,7 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
       """
     ],
     sample_weights: [
-      type:
-        {:or,
-         [
-           {:custom, Scholar.Options, :non_negative_number, []},
-           {:list, {:custom, Scholar.Options, :non_negative_number, []}},
-           {:custom, Scholar.Options, :weights, []}
-         ]},
+      type: {:custom, Scholar.Options, :weights, []},
       doc: """
       The weights for each observation. If not provided,
       all observations are assigned equal weight.

--- a/lib/scholar/linear/linear_helpers.ex
+++ b/lib/scholar/linear/linear_helpers.ex
@@ -43,14 +43,20 @@ defmodule Scholar.Linear.LinearHelpers do
   # targets by sqrt(sample_weight).
   @doc false
   defn rescale(x, y, sample_weights) do
-    case Nx.shape(sample_weights) do
-      {} = scalar ->
-        scalar = Nx.sqrt(scalar)
-        {scalar * x, scalar * y}
+    factor = Nx.sqrt(sample_weights)
 
-      _ ->
-        scale = sample_weights |> Nx.sqrt() |> Nx.make_diagonal()
-        {Nx.dot(scale, x), Nx.dot(scale, y)}
-    end
+    x_scaled =
+      case Nx.shape(factor) do
+        {} -> factor * x
+        _ -> x * Nx.new_axis(factor, -1)
+      end
+
+    y_scaled =
+      case Nx.rank(y) do
+        1 -> factor * y
+        _ -> y * Nx.new_axis(factor, -1)
+      end
+
+    {x_scaled, y_scaled}
   end
 end

--- a/lib/scholar/linear/linear_helpers.ex
+++ b/lib/scholar/linear/linear_helpers.ex
@@ -12,6 +12,7 @@ defmodule Scholar.Linear.LinearHelpers do
     default_sample_weights = Nx.broadcast(Nx.as_type(1.0, x_type), {num_samples})
     {sample_weights, _} = Keyword.pop(opts, :sample_weights, default_sample_weights)
 
+    # this is required for ridge regression
     sample_weights =
       if Nx.is_tensor(sample_weights),
         do: Nx.as_type(sample_weights, x_type),

--- a/lib/scholar/linear/linear_helpers.ex
+++ b/lib/scholar/linear/linear_helpers.ex
@@ -1,0 +1,51 @@
+defmodule Scholar.Linear.LinearHelpers do
+  require Nx
+  import Nx.Defn
+
+  @moduledoc false
+
+  @doc false
+  defn preprocess_data(x, y, sample_weights, opts) do
+    if opts[:sample_weights_flag],
+      do:
+        {Nx.weighted_mean(x, sample_weights, axes: [0]),
+         Nx.weighted_mean(y, sample_weights, axes: [0])},
+      else: {Nx.mean(x, axes: [0]), Nx.mean(y, axes: [0])}
+  end
+
+  @doc false
+  defn set_intercept(coeff, x_offset, y_offset, fit_intercept?) do
+    if fit_intercept? do
+      y_offset - Nx.dot(coeff, x_offset)
+    else
+      Nx.tensor(0.0, type: Nx.type(coeff))
+    end
+  end
+
+  # Implements sample weighting by rescaling inputs and
+  # targets by sqrt(sample_weight).
+  @doc false
+  defn rescale(x, y, sample_weights) do
+    case Nx.shape(sample_weights) do
+      {} = scalar ->
+        scalar = Nx.sqrt(scalar)
+        {scalar * x, scalar * y}
+
+      _ ->
+        scale = sample_weights |> Nx.sqrt() |> Nx.make_diagonal()
+        {Nx.dot(scale, x), Nx.dot(scale, y)}
+    end
+  end
+
+  # defn rescale(x, y, sample_weights) do
+  #   factor = Nx.sqrt(sample_weights)
+
+  #   x_scaled =
+  #     case Nx.shape(factor) do
+  #       {} -> factor * x
+  #       _ -> Nx.new_axis(factor, 1) * x
+  #     end
+
+  #   {x_scaled, factor * y}
+  # end
+end

--- a/lib/scholar/linear/linear_helpers.ex
+++ b/lib/scholar/linear/linear_helpers.ex
@@ -52,16 +52,4 @@ defmodule Scholar.Linear.LinearHelpers do
         {Nx.dot(scale, x), Nx.dot(scale, y)}
     end
   end
-
-  # defn rescale(x, y, sample_weights) do
-  #   factor = Nx.sqrt(sample_weights)
-
-  #   x_scaled =
-  #     case Nx.shape(factor) do
-  #       {} -> factor * x
-  #       _ -> Nx.new_axis(factor, 1) * x
-  #     end
-
-  #   {x_scaled, factor * y}
-  # end
 end

--- a/lib/scholar/linear/linear_helpers.ex
+++ b/lib/scholar/linear/linear_helpers.ex
@@ -1,8 +1,24 @@
 defmodule Scholar.Linear.LinearHelpers do
   require Nx
   import Nx.Defn
+  import Scholar.Shared
 
   @moduledoc false
+
+  @doc false
+  def build_sample_weights(x, opts) do
+    x_type = to_float_type(x)
+    {num_samples, _} = Nx.shape(x)
+    default_sample_weights = Nx.broadcast(Nx.as_type(1.0, x_type), {num_samples})
+    {sample_weights, _} = Keyword.pop(opts, :sample_weights, default_sample_weights)
+
+    sample_weights =
+      if Nx.is_tensor(sample_weights),
+        do: Nx.as_type(sample_weights, x_type),
+        else: Nx.tensor(sample_weights, type: x_type)
+
+    sample_weights
+  end
 
   @doc false
   defn preprocess_data(x, y, sample_weights, opts) do

--- a/lib/scholar/linear/linear_regression.ex
+++ b/lib/scholar/linear/linear_regression.ex
@@ -76,13 +76,7 @@ defmodule Scholar.Linear.LinearRegression do
       ] ++
         opts
 
-    {sample_weights, opts} = Keyword.pop(opts, :sample_weights, 1.0)
-    x_type = to_float_type(x)
-
-    sample_weights =
-      if Nx.is_tensor(sample_weights),
-        do: Nx.as_type(sample_weights, x_type),
-        else: Nx.tensor(sample_weights, type: x_type)
+    sample_weights = LinearHelpers.build_sample_weights(x, opts)
 
     fit_n(x, y, sample_weights, opts)
   end

--- a/lib/scholar/linear/linear_regression.ex
+++ b/lib/scholar/linear/linear_regression.ex
@@ -8,6 +8,7 @@ defmodule Scholar.Linear.LinearRegression do
   require Nx
   import Nx.Defn
   import Scholar.Shared
+  alias Scholar.Linear.LinearHelpers
 
   @derive {Nx.Container, containers: [:coefficients, :intercept]}
   defstruct [:coefficients, :intercept]
@@ -92,7 +93,7 @@ defmodule Scholar.Linear.LinearRegression do
 
     {a_offset, b_offset} =
       if opts[:fit_intercept?] do
-        preprocess_data(a, b, sample_weights, opts)
+        LinearHelpers.preprocess_data(a, b, sample_weights, opts)
       else
         a_offset_shape = Nx.axis_size(a, 1)
         b_reshaped = if Nx.rank(b) > 1, do: b, else: Nx.reshape(b, {:auto, 1})
@@ -106,7 +107,7 @@ defmodule Scholar.Linear.LinearRegression do
 
     {a, b} =
       if opts[:sample_weights_flag] do
-        rescale(a, b, sample_weights)
+        LinearHelpers.rescale(a, b, sample_weights)
       else
         {a, b}
       end
@@ -132,42 +133,12 @@ defmodule Scholar.Linear.LinearRegression do
     Nx.dot(x, coeff) + intercept
   end
 
-  # Implements sample weighting by rescaling inputs and
-  # targets by sqrt(sample_weight).
-  defnp rescale(x, y, sample_weights) do
-    case Nx.shape(sample_weights) do
-      {} = scalar ->
-        scalar = Nx.sqrt(scalar)
-        {scalar * x, scalar * y}
-
-      _ ->
-        scale = sample_weights |> Nx.sqrt() |> Nx.make_diagonal()
-        {Nx.dot(scale, x), Nx.dot(scale, y)}
-    end
-  end
-
   # Implements ordinary least-squares by estimating the
   # solution A to the equation A.X = b.
   defnp lstsq(a, b, a_offset, b_offset, fit_intercept?) do
     pinv = Nx.LinAlg.pinv(a)
     coeff = Nx.dot(b, [0], pinv, [1])
-    intercept = set_intercept(coeff, a_offset, b_offset, fit_intercept?)
+    intercept = LinearHelpers.set_intercept(coeff, a_offset, b_offset, fit_intercept?)
     {coeff, intercept}
-  end
-
-  defnp set_intercept(coeff, x_offset, y_offset, fit_intercept?) do
-    if fit_intercept? do
-      y_offset - Nx.dot(coeff, x_offset)
-    else
-      Nx.tensor(0.0, type: Nx.type(coeff))
-    end
-  end
-
-  defnp preprocess_data(x, y, sample_weights, opts) do
-    if opts[:sample_weights_flag],
-      do:
-        {Nx.weighted_mean(x, sample_weights, axes: [0]),
-         Nx.weighted_mean(y, sample_weights, axes: [0])},
-      else: {Nx.mean(x, axes: [0]), Nx.mean(y, axes: [0])}
   end
 end

--- a/lib/scholar/linear/polynomial_regression.ex
+++ b/lib/scholar/linear/polynomial_regression.ex
@@ -12,7 +12,7 @@ defmodule Scholar.Linear.PolynomialRegression do
 
   opts = [
     sample_weights: [
-      type: {:list, {:custom, Scholar.Options, :positive_number, []}},
+      type: {:custom, Scholar.Options, :weights, []},
       doc: """
       The weights for each observation. If not provided,
       all observations are assigned equal weight.

--- a/lib/scholar/linear/ridge_regression.ex
+++ b/lib/scholar/linear/ridge_regression.ex
@@ -29,7 +29,7 @@ defmodule Scholar.Linear.RidgeRegression do
 
   opts = [
     sample_weights: [
-      type: {:custom, Scholar.Options, :weights, []},      
+      type: {:custom, Scholar.Options, :weights, []},
       doc: """
       The weights for each observation. If not provided,
       all observations are assigned equal weight.
@@ -121,13 +121,9 @@ defmodule Scholar.Linear.RidgeRegression do
       ] ++
         opts
 
-    {sample_weights, opts} = Keyword.pop(opts, :sample_weights, 1.0)
     x_type = to_float_type(x)
 
-    sample_weights =
-      if Nx.is_tensor(sample_weights),
-        do: Nx.as_type(sample_weights, x_type),
-        else: Nx.tensor(sample_weights, type: x_type)
+    sample_weights = LinearHelpers.build_sample_weights(x, opts)
 
     {alpha, opts} = Keyword.pop!(opts, :alpha)
     alpha = Nx.tensor(alpha, type: x_type) |> Nx.flatten()

--- a/lib/scholar/linear/ridge_regression.ex
+++ b/lib/scholar/linear/ridge_regression.ex
@@ -29,13 +29,7 @@ defmodule Scholar.Linear.RidgeRegression do
 
   opts = [
     sample_weights: [
-      type:
-        {:or,
-         [
-           {:custom, Scholar.Options, :non_negative_number, []},
-           {:list, {:custom, Scholar.Options, :non_negative_number, []}},
-           {:custom, Scholar.Options, :weights, []}
-         ]},
+      type: {:custom, Scholar.Options, :weights, []},      
       doc: """
       The weights for each observation. If not provided,
       all observations are assigned equal weight.

--- a/test/scholar/linear/bayesian_ridge_regression_test.exs
+++ b/test/scholar/linear/bayesian_ridge_regression_test.exs
@@ -53,7 +53,7 @@ defmodule Scholar.Linear.BayesianRidgeRegressionTest do
     score = compute_score(x, y, alpha, lambda, alpha_1, alpha_2, lambda_1, lambda_2)
 
     brr =
-      BayesianRidgeRegression.fit(x, y,
+      BayesianRidgeRegression.fit(x, Nx.flatten(y),
         alpha_1: alpha_1,
         alpha_2: alpha_2,
         lambda_1: lambda_1,


### PR DESCRIPTION
Implements the suggestion from [here](https://github.com/elixir-nx/scholar/issues/249).

I've had to revert the change suggested by @krstopro [here](https://github.com/elixir-nx/scholar/pull/247#discussion_r1573718068), as that change made some tests from `LinearRegression` and `RidgeRegression` fail.

When it comes to ` LinearRegression`  I believe those failures are related to the shape of the target data: 
- The tests yield failures when the data is 2 dimensional, [like a column vector](https://github.com/elixir-nx/scholar/blob/322687a04ea0f701efdf42fd6360627a0ed30518/test/scholar/linear/linear_regression_test.exs#L132)
- Flattening those data yield a passing test.

`RidgeRegression` tests fail with multi-output target data. These cannot be flattened.