### PR TITLE
use Nx.BinaryBackend for cv notebook

### DIFF
--- a/notebooks/cv_gradient_boosting_tree.livemd
+++ b/notebooks/cv_gradient_boosting_tree.livemd
@@ -23,13 +23,6 @@ require Explorer.DataFrame, as: DF
 require Explorer.Series, as: S
 ```
 
-And let's configure `EXLA` as our default backend (where our tensors are stored) and compiler (which compiles Scholar code) across the notebook and all branched sections:
-
-```elixir
-Nx.global_default_backend(EXLA.Backend)
-Nx.Defn.global_default_options(compiler: EXLA)
-```
-
 We are going to work with [Medical Cost Personal Datasets](https://www.kaggle.com/datasets/mirichoi0218/insurance) to predict medical charges that were applied to each person from the dataset. Let's download it:
 
 ```elixir

--- a/notebooks/cv_gradient_boosting_tree.livemd
+++ b/notebooks/cv_gradient_boosting_tree.livemd
@@ -3,14 +3,13 @@
 ```elixir
 Mix.install([
   {:scholar, "~> 0.2.0"},
-  {:explorer, "~> 0.6.1"},
-  {:exla, "~> 0.6.0"},
-  {:nx, "~> 0.6.0", override: true},
   {:exgboost, "~> 0.3"},
   {:req, "~> 0.3.9"},
   {:kino_vega_lite, "~> 0.1.9"},
   {:kino, "~> 0.10.0"},
-  {:kino_explorer, "~> 0.1.7"}
+  {:kino_explorer, "~> 0.1.7"},
+  {:nx, "~> 0.7.2"},
+  {:explorer, "~> 0.8.2"}
 ])
 ```
 


### PR DESCRIPTION
Removes setup cell that sets EXLA as default backend and compiler. This is not supported for EXGBoost at the time.