### PR TITLE
Added batching to regression metrics

### DIFF
--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -25,16 +25,17 @@ defmodule Scholar.Metrics.Regression do
     ]
   ]
 
-  r2_schema = [
-    force_finite: [
-      type: :boolean,
-      default: true,
-      doc: """
-      Flag indicating if NaN and -Inf scores resulting from constant data should be replaced with real numbers
-      (1.0 if prediction is perfect, 0.0 otherwise)
-      """
-    ]
-  ] ++ general_schema
+  r2_schema =
+    [
+      force_finite: [
+        type: :boolean,
+        default: true,
+        doc: """
+        Flag indicating if NaN and -Inf scores resulting from constant data should be replaced with real numbers
+        (1.0 if prediction is perfect, 0.0 otherwise)
+        """
+      ]
+    ] ++ general_schema
 
   @general_schema NimbleOptions.new!(general_schema)
   @r2_schema NimbleOptions.new!(r2_schema)
@@ -641,29 +642,30 @@ defmodule Scholar.Metrics.Regression do
     Nx.reduce_max(Nx.abs(y_true - y_pred))
   end
 
-  mean_pinball_loss_opts = [
-    alpha: [
-      type: :float,
-      default: 0.5,
-      doc: """
-      The slope of the pinball loss, default=0.5,
-      This loss is equivalent to $$mean_absolute_error$$ when $$\alpha$$ is 0.5,
-      $$\alpha = 0.95$$ is minimized by estimators of the 95th percentile.
-      """
-    ],
-    sample_weights: [
-      type:
-        {:or,
-         [
-           {:custom, Scholar.Options, :weights, []},
-           {:custom, Scholar.Options, :multi_weights, []}
-         ]},
-      doc: """
-      The weights for each observation. If not provided,
-      all observations are assigned equal weight.
-      """
-    ]
-  ] ++ general_schema
+  mean_pinball_loss_opts =
+    [
+      alpha: [
+        type: :float,
+        default: 0.5,
+        doc: """
+        The slope of the pinball loss, default=0.5,
+        This loss is equivalent to $$mean_absolute_error$$ when $$\alpha$$ is 0.5,
+        $$\alpha = 0.95$$ is minimized by estimators of the 95th percentile.
+        """
+      ],
+      sample_weights: [
+        type:
+          {:or,
+           [
+             {:custom, Scholar.Options, :weights, []},
+             {:custom, Scholar.Options, :multi_weights, []}
+           ]},
+        doc: """
+        The weights for each observation. If not provided,
+        all observations are assigned equal weight.
+        """
+      ]
+    ] ++ general_schema
 
   @mean_pinball_loss_schema NimbleOptions.new!(mean_pinball_loss_opts)
 
@@ -704,10 +706,13 @@ defmodule Scholar.Metrics.Regression do
   defnp mean_pinball_loss_n(y_true, y_pred, opts) do
     assert_same_shape!(y_true, y_pred)
     alpha = opts[:alpha]
-    weights = case opts[:sample_weights] do 
-      nil -> Nx.broadcast(1, y_true)
-      sample_weights -> sample_weights
-    end
+
+    weights =
+      case opts[:sample_weights] do
+        nil -> Nx.broadcast(1, y_true)
+        sample_weights -> sample_weights
+      end
+
     # Formula adapted from sklearn:
     # https://github.com/scikit-learn/scikit-learn/blob/128e40ed593c57e8b9e57a4109928d58fa8bf359/sklearn/metrics/_regression.py#L299
     diff = y_true - y_pred
@@ -797,17 +802,18 @@ defmodule Scholar.Metrics.Regression do
     d2_pinball_score(y_true, y_pred, alpha: 0.5, axes: opts[:axes])
   end
 
-  d2_pinball_score_opts = [
-    alpha: [
-      type: :float,
-      default: 0.5,
-      doc: """
-      The slope of the pinball loss, default=0.5,
-      This loss is equivalent to $$mean_absolute_error$$ when $$\alpha$$ is 0.5,
-      $$\alpha = 0.95$$ is minimized by estimators of the 95th percentile.
-      """
-    ]
-  ] ++ general_schema
+  d2_pinball_score_opts =
+    [
+      alpha: [
+        type: :float,
+        default: 0.5,
+        doc: """
+        The slope of the pinball loss, default=0.5,
+        This loss is equivalent to $$mean_absolute_error$$ when $$\alpha$$ is 0.5,
+        $$\alpha = 0.95$$ is minimized by estimators of the 95th percentile.
+        """
+      ]
+    ] ++ general_schema
 
   @d2_pinball_score_schema NimbleOptions.new!(d2_pinball_score_opts)
 
@@ -890,8 +896,10 @@ defmodule Scholar.Metrics.Regression do
     output_scores =
       Nx.select(valid_score, Nx.subtract(1, Nx.divide(numerator, denominator)), output_scores)
 
-    loss = Nx.select(invalid_score, 0.0, output_scores)
-    |> Nx.broadcast(shape)
+    loss =
+      Nx.select(invalid_score, 0.0, output_scores)
+      |> Nx.broadcast(shape)
+
     Nx.mean(loss, axes: opts[:axes])
   end
 

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -82,30 +82,7 @@ defmodule Scholar.Metrics.RegressionTest do
       assert Regression.mean_pinball_loss(y_true, y_pred_2, alpha: 0.4) == Nx.tensor(0.4)
     end
 
-    test "mean_pinball_loss with sample weight" do
-      y_true = Nx.tensor([1, 2, 3, 4, 5, 6])
-      y_pred = Nx.tensor([2, 3, 4, 6, 7, 8])
-      sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5])
-      wrong_sample_weights = Nx.tensor([1.5, 1.5, 1.5, 0.5, 0.5, 0.5, 1, 1, 1])
-
-      assert Regression.mean_pinball_loss(y_true, y_pred) == Nx.tensor(0.75)
-
-      assert Regression.mean_pinball_loss(
-               y_true,
-               y_pred,
-               alpha: 0.5,
-               sample_weights: sample_weights
-             ) == Nx.tensor(0.625)
-
-      assert_raise ArgumentError, fn ->
-        Regression.mean_pinball_loss(y_true, y_pred,
-          alpha: 0.5,
-          sample_weights: wrong_sample_weights
-        )
-      end
-    end
-
-    test "mean_pinball_loss with multioutput" do
+    test "mean_pinball_loss with axes" do
       y_true = Nx.tensor([[1, 0, 0, 1], [0, 1, 1, 1], [1, 1, 0, 1]])
       y_pred = Nx.tensor([[0, 0, 0, 1], [1, 0, 1, 1], [0, 0, 0, 1]])
 
@@ -123,19 +100,18 @@ defmodule Scholar.Metrics.RegressionTest do
         Regression.mean_pinball_loss(
           y_true,
           y_pred,
-          alpha: 0.5,
-          multioutput: :uniform_average
+          alpha: 0.5
         )
 
       assert_all_close(mpbl, expected_error)
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.5, multioutput: :raw_values)
+      mpbl = Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.5, axes: [0])
       assert_all_close(mpbl, expected_raw_values_tensor)
 
       mpbl =
         Regression.mean_pinball_loss(y_true, y_pred,
           alpha: 0.5,
           sample_weights: sample_weight,
-          multioutput: :raw_values
+          axes: [0]
         )
 
       assert_all_close(mpbl, expected_raw_values_weighted_tensor)
@@ -143,21 +119,10 @@ defmodule Scholar.Metrics.RegressionTest do
       mpbl =
         Regression.mean_pinball_loss(y_true, y_pred,
           alpha: 0.5,
-          sample_weights: sample_weight,
-          multioutput: :uniform_average
+          sample_weights: sample_weight
         )
 
       assert_all_close(mpbl, Nx.tensor(0.225))
-
-      mpbl =
-        Regression.mean_pinball_loss(y_true, y_pred,
-          alpha: 0.5,
-          multioutput: Nx.tensor([1, 2, 3, 4])
-        )
-
-      assert_all_close(mpbl, Nx.tensor(0.1166666))
-      mpbl = Regression.mean_pinball_loss(y_true, y_pred, alpha: 0.5, multioutput: nil)
-      assert_all_close(mpbl, expected_error)
     end
   end
 end


### PR DESCRIPTION
Following up on #144 issue:

I've added batching to the `Regression` metrics, similar to the batching implemented in the `Distances` metrics. However, I'm not entirely sure if I fully understood the issue, so I would greatly appreciate any feedback.

I did not make changes to the following metrics:

- `mean_pinball_loss`
- `d2_absolute_error_score`
- `d2_pinball_score`

These metrics appear to already support batching through the `:multioutput` argument. If that's the case, perhaps we should consider standardizing the argument to `:axes` for consistency across similar functions.

Please let me know if I’m mistaken about anything.