### PR TITLE
Add spectral clustering

### DIFF
--- a/lib/scholar/cluster/spectral_clustering.ex
+++ b/lib/scholar/cluster/spectral_clustering.ex
@@ -1,0 +1,210 @@
+defmodule Scholar.Cluster.SpectralClustering do
+  @moduledoc """
+  Spectral clustering.
+
+  Applies clustering to a projection of the normalized graph Laplacian [1].
+  Instead of clustering the points in their original space, the algorithm
+  builds an affinity (similarity) matrix between all pairs of samples,
+  computes the eigenvectors associated with the smallest eigenvalues of its
+  normalized graph Laplacian, and runs k-means on that spectral embedding.
+
+  In practice spectral clustering is very useful when the individual
+  clusters are non-convex (e.g. nested circles), a setting where plain
+  k-means on the original space performs poorly [2].
+
+  The eigendecomposition of the dense `{num_samples, num_samples}` Laplacian
+  gives a time complexity of $O(N^3)$ and a memory complexity of $O(N^2)$,
+  where $N$ is the number of samples.
+
+  References:
+
+  * [1] - [A Tutorial on Spectral Clustering, Ulrike von Luxburg](https://arxiv.org/abs/0711.0189)
+  * [2] - [On Spectral Clustering: Analysis and an algorithm, Ng, Jordan & Weiss](https://proceedings.neurips.cc/paper_files/paper/2001/file/801272ee79cfde7fa5960571fee36b9b-Paper.pdf)
+  """
+  import Nx.Defn
+
+  @derive {Nx.Container, containers: [:labels, :embedding]}
+  defstruct [:labels, :embedding]
+
+  opts = [
+    num_clusters: [
+      required: true,
+      type: :pos_integer,
+      doc: "The number of clusters to form, as well as the dimension of the spectral embedding."
+    ],
+    affinity: [
+      type: {:in, [:rbf, :precomputed]},
+      default: :rbf,
+      doc: """
+      How to construct the affinity matrix, either of:
+
+      * `:rbf` - construct the affinity matrix using a radial basis function (RBF) kernel,
+        $\\exp(-\\gamma \\|x_i - x_j\\|^2)$.
+
+      * `:precomputed` - interpret the input as a precomputed affinity matrix, i.e.
+        a symmetric `{num_samples, num_samples}` tensor of non-negative similarities.
+      """
+    ],
+    gamma: [
+      type: {:custom, Scholar.Options, :positive_number, []},
+      default: 1.0,
+      doc: "Kernel coefficient for the `:rbf` affinity. Ignored for `:precomputed`."
+    ],
+    num_runs: [
+      type: :pos_integer,
+      default: 10,
+      doc: """
+      Number of times the k-means algorithm will be run on the spectral embedding
+      with different centroid seeds. The final result is the best output in terms
+      of inertia.
+      """
+    ],
+    max_iterations: [
+      type: :pos_integer,
+      default: 300,
+      doc: "Maximum number of iterations of the k-means algorithm for a single run."
+    ],
+    key: [
+      type: {:custom, Scholar.Options, :key, []},
+      doc: """
+      Determines random number generation for centroid initialization of the
+      k-means step. If the key is not provided, it is set to `Nx.Random.key(System.system_time())`.
+      """
+    ]
+  ]
+
+  @opts_schema NimbleOptions.new!(opts)
+
+  @doc """
+  Performs spectral clustering on the sample inputs `x`.
+
+  If `affinity: :rbf` (the default), `x` is expected to be a
+  `{num_samples, num_features}` tensor of samples. If `affinity: :precomputed`,
+  `x` is expected to be a symmetric `{num_samples, num_samples}` affinity matrix.
+
+  Self-loops are discarded when building the graph Laplacian, i.e. the diagonal
+  of the affinity matrix is ignored, matching `scipy.sparse.csgraph.laplacian`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  ## Return Values
+
+  The function returns a struct with the following parameters:
+
+    * `:labels` - Cluster labels of each point.
+
+    * `:embedding` - The `{num_samples, num_clusters}` spectral embedding, i.e. the
+      eigenvectors of the normalized graph Laplacian associated with its
+      `num_clusters` smallest eigenvalues, rescaled as in the relaxed Ncut problem
+      ($u = D^{-1/2} v$) and with a deterministic sign (the entry with the largest
+      absolute value of each eigenvector is positive).
+
+  ## Examples
+
+      iex> key = Nx.Random.key(42)
+      iex> x = Nx.tensor([[0.0, 0.0], [0.1, 0.1], [3.0, 3.0], [3.1, 3.1]])
+      iex> Scholar.Cluster.SpectralClustering.fit(x, num_clusters: 2, key: key).labels
+      #Nx.Tensor<
+        s32[4]
+        [0, 0, 1, 1]
+      >
+  """
+  deftransform fit(x, opts \\ []) do
+    if Nx.rank(x) != 2 do
+      raise ArgumentError,
+            "expected input tensor to have shape {num_samples, num_features} or " <>
+              "{num_samples, num_samples}, got tensor with shape: #{inspect(Nx.shape(x))}"
+    end
+
+    opts = NimbleOptions.validate!(opts, @opts_schema)
+    num_samples = Nx.axis_size(x, 0)
+
+    if num_samples < 2 do
+      raise ArgumentError, "expected at least 2 samples, got: #{num_samples}"
+    end
+
+    if opts[:affinity] == :precomputed and Nx.axis_size(x, 1) != num_samples do
+      raise ArgumentError,
+            "expected a square affinity matrix for affinity: :precomputed, " <>
+              "got tensor with shape: #{inspect(Nx.shape(x))}"
+    end
+
+    unless opts[:num_clusters] <= num_samples do
+      raise ArgumentError,
+            "invalid value for :num_clusters option: expected positive integer " <>
+              "between 1 and #{inspect(num_samples)}, got: #{inspect(opts[:num_clusters])}"
+    end
+
+    key = Keyword.get_lazy(opts, :key, fn -> Nx.Random.key(System.system_time()) end)
+
+    # The stopping criterion of Nx.LinAlg.eigh must match the input precision:
+    # a criterion below the floating-point resolution makes the iteration
+    # accumulate noise past convergence.
+    eigh_eps = if Nx.type(x) == {:f, 64}, do: 1.0e-11, else: 1.0e-8
+
+    embedding =
+      spectral_embedding(x,
+        num_clusters: opts[:num_clusters],
+        affinity: opts[:affinity],
+        gamma: opts[:gamma],
+        eigh_eps: eigh_eps
+      )
+
+    kmeans =
+      Scholar.Cluster.KMeans.fit(embedding,
+        num_clusters: opts[:num_clusters],
+        num_runs: opts[:num_runs],
+        max_iterations: opts[:max_iterations],
+        key: key
+      )
+
+    %__MODULE__{labels: kmeans.labels, embedding: embedding}
+  end
+
+  defnp spectral_embedding(x, opts) do
+    affinity =
+      case opts[:affinity] do
+        :rbf ->
+          Nx.exp(-opts[:gamma] * Scholar.Metrics.Distance.pairwise_squared_euclidean(x))
+
+        :precomputed ->
+          Scholar.Shared.to_float(x)
+      end
+
+    num_samples = Nx.axis_size(affinity, 0)
+    num_clusters = opts[:num_clusters]
+
+    # Self-loops are discarded before computing the degrees, matching
+    # scikit-learn (`scipy.sparse.csgraph.laplacian`).
+    eye = Nx.eye(num_samples, type: Nx.type(affinity))
+    affinity = affinity * (1 - eye)
+
+    degrees = Nx.sum(affinity, axes: [1])
+    dd = Nx.select(degrees == 0, 1, Nx.sqrt(degrees))
+
+    # Symmetric normalized Laplacian L = I - D^-1/2 A D^-1/2. Isolated vertices
+    # keep a unit diagonal, as scikit-learn does via `_set_diag(laplacian, 1)`.
+    laplacian = -(affinity / dd / Nx.new_axis(dd, -1)) + eye
+
+    # The division can leave tiny floating-point asymmetries; eigh requires an
+    # exactly symmetric input.
+    laplacian = (laplacian + Nx.transpose(laplacian)) / 2
+
+    # eigh returns unit eigenvectors, but not necessarily sorted, so the
+    # num_clusters smallest eigenvalues are selected explicitly.
+    {eigenvalues, eigenvectors} = Nx.LinAlg.eigh(laplacian, eps: opts[:eigh_eps])
+    order = Nx.argsort(eigenvalues, direction: :asc)
+    vectors = Nx.take(eigenvectors, order[0..(num_clusters - 1)//1], axis: 1)
+
+    # Recover u = D^-1/2 v, the solution of the relaxed Ncut problem.
+    embedding = vectors / Nx.new_axis(dd, -1)
+
+    # Deterministic sign: the largest-magnitude entry of each vector is made
+    # positive, as in scikit-learn's `_deterministic_vector_sign_flip`.
+    max_abs = embedding |> Nx.abs() |> Nx.argmax(axis: 0, keep_axis: true)
+    signs = embedding |> Nx.take_along_axis(max_abs, axis: 0) |> Nx.sign()
+    embedding * signs
+  end
+end

--- a/lib/scholar/cluster/spectral_clustering.ex
+++ b/lib/scholar/cluster/spectral_clustering.ex
@@ -144,15 +144,29 @@ defmodule Scholar.Cluster.SpectralClustering do
     # accumulate noise past convergence.
     eigh_eps = if Nx.type(x) == {:f, 64}, do: 1.0e-11, else: 1.0e-8
 
+    {labels, embedding} =
+      fit_n(x, key,
+        num_clusters: opts[:num_clusters],
+        affinity: opts[:affinity],
+        gamma: opts[:gamma],
+        eigh_eps: eigh_eps,
+        num_runs: opts[:num_runs],
+        max_iterations: opts[:max_iterations]
+      )
+
+    %__MODULE__{labels: labels, embedding: embedding}
+  end
+
+  defnp fit_n(x, key, opts) do
     embedding =
       spectral_embedding(x,
         num_clusters: opts[:num_clusters],
         affinity: opts[:affinity],
         gamma: opts[:gamma],
-        eigh_eps: eigh_eps
+        eigh_eps: opts[:eigh_eps]
       )
 
-    kmeans =
+    model =
       Scholar.Cluster.KMeans.fit(embedding,
         num_clusters: opts[:num_clusters],
         num_runs: opts[:num_runs],
@@ -160,7 +174,7 @@ defmodule Scholar.Cluster.SpectralClustering do
         key: key
       )
 
-    %__MODULE__{labels: kmeans.labels, embedding: embedding}
+    {model.labels, embedding}
   end
 
   defnp spectral_embedding(x, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -72,6 +72,7 @@ defmodule Scholar.MixProject do
           Scholar.Cluster.GaussianMixture,
           Scholar.Cluster.Hierarchical,
           Scholar.Cluster.KMeans,
+          Scholar.Cluster.SpectralClustering,
           Scholar.Decomposition.KernelPCA,
           Scholar.Decomposition.PCA,
           Scholar.Integrate,

--- a/test/scholar/cluster/spectral_clustering_test.exs
+++ b/test/scholar/cluster/spectral_clustering_test.exs
@@ -1,0 +1,315 @@
+defmodule Scholar.Cluster.SpectralClusteringTest do
+  use Scholar.Case, async: true
+
+  alias Scholar.Cluster.SpectralClustering
+
+  doctest SpectralClustering
+
+  defp key, do: Nx.Random.key(42)
+
+  # Compares two label assignments as partitions, i.e. up to a permutation of
+  # the label ids (which are arbitrary for clustering algorithms).
+  defp assert_same_partition(labels, reference) do
+    assert canonical_partition(Nx.to_flat_list(labels)) == canonical_partition(reference)
+  end
+
+  defp canonical_partition(labels) do
+    labels
+    |> Enum.reduce({%{}, []}, fn label, {mapping, acc} ->
+      mapping = Map.put_new(mapping, label, map_size(mapping))
+      {mapping, [mapping[label] | acc]}
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  describe "spectral embedding" do
+    # A connected graph with distinct Laplacian eigenvalues, so the embedding
+    # is unique (up to sign, fixed by the deterministic sign flip) and can be
+    # compared against scikit-learn value by value. Reference values from
+    # sklearn 1.6.1 (rbf affinity, normalized Laplacian, u = D^-1/2 v).
+    test "matches sklearn on a connected graph (f64)" do
+      x =
+        Nx.tensor(
+          [
+            [0.0, 0.0],
+            [0.3, 0.2],
+            [0.2, 0.4],
+            [0.4, 0.1],
+            [1.5, 1.4],
+            [1.7, 1.6],
+            [1.6, 1.8],
+            [1.8, 1.5]
+          ],
+          type: :f64
+        )
+
+      model = SpectralClustering.fit(x, num_clusters: 2, key: key())
+
+      expected =
+        Nx.tensor(
+          [
+            [0.21119082386324414, 0.22170302981050768],
+            [0.21119082386324428, 0.21243951255638854],
+            [0.21119082386324425, 0.20868001640905082],
+            [0.21119082386324428, 0.21225159060755805],
+            [0.2111908238632471, -0.19700947261064472],
+            [0.21119082386324736, -0.21205548793328316],
+            [0.2111908238632475, -0.21380727833466814],
+            [0.2111908238632474, -0.21197409305730497]
+          ],
+          type: :f64
+        )
+
+      assert Nx.type(model.embedding) == {:f, 64}
+      assert_all_close(model.embedding, expected, atol: 1.0e-5)
+      assert_same_partition(model.labels, [1, 1, 1, 1, 0, 0, 0, 0])
+    end
+
+    test "matches sklearn with a precomputed affinity (f64)" do
+      affinity =
+        Nx.tensor(
+          [
+            [1.0, 0.9, 0.8, 0.1, 0.0],
+            [0.9, 1.0, 0.85, 0.05, 0.1],
+            [0.8, 0.85, 1.0, 0.1, 0.05],
+            [0.1, 0.05, 0.1, 1.0, 0.95],
+            [0.0, 0.1, 0.05, 0.95, 1.0]
+          ],
+          type: :f64
+        )
+
+      model =
+        SpectralClustering.fit(affinity,
+          num_clusters: 2,
+          affinity: :precomputed,
+          key: key()
+        )
+
+      expected =
+        Nx.tensor(
+          [
+            [0.3580574370197165, -0.24303023799947535],
+            [0.3580574370197158, -0.22694330499537213],
+            [0.35805743701971593, -0.22451947994046756],
+            [0.35805743701971704, 0.5360175324304737],
+            [0.35805743701971726, 0.5723279389695742]
+          ],
+          type: :f64
+        )
+
+      assert_all_close(model.embedding, expected, atol: 1.0e-5)
+      assert_same_partition(model.labels, [0, 0, 0, 1, 1])
+    end
+  end
+
+  describe "labels" do
+    # For well-separated blobs the graph is effectively disconnected and the
+    # smallest eigenvalues are degenerate, so the embedding itself is only
+    # unique up to a rotation. The partition, however, is stable and must
+    # match scikit-learn's.
+    test "two well-separated blobs match sklearn's partition" do
+      x =
+        Nx.tensor([
+          [0.0, 0.0],
+          [0.2, 0.1],
+          [0.1, 0.3],
+          [0.3, 0.2],
+          [5.0, 5.0],
+          [5.2, 5.1],
+          [5.1, 5.3],
+          [5.3, 5.2]
+        ])
+
+      model = SpectralClustering.fit(x, num_clusters: 2, key: key())
+      assert_same_partition(model.labels, [1, 1, 1, 1, 0, 0, 0, 0])
+      assert Nx.shape(model.embedding) == {8, 2}
+    end
+
+    test "three blobs match sklearn's partition" do
+      x =
+        Nx.tensor([
+          [0.0, 0.0],
+          [0.1, 0.2],
+          [0.2, 0.1],
+          [4.0, 4.0],
+          [4.1, 4.2],
+          [4.2, 4.1],
+          [8.0, 0.0],
+          [8.1, 0.2],
+          [8.2, 0.1]
+        ])
+
+      model = SpectralClustering.fit(x, num_clusters: 3, key: key())
+      assert_same_partition(model.labels, [1, 1, 1, 2, 2, 2, 0, 0, 0])
+      assert Nx.shape(model.embedding) == {9, 3}
+    end
+
+    test "custom gamma matches sklearn's partition" do
+      x =
+        Nx.tensor([
+          [0.0, 0.0],
+          [0.2, 0.1],
+          [0.1, 0.3],
+          [0.3, 0.2],
+          [5.0, 5.0],
+          [5.2, 5.1],
+          [5.1, 5.3],
+          [5.3, 5.2]
+        ])
+
+      model = SpectralClustering.fit(x, num_clusters: 2, gamma: 0.5, key: key())
+      assert_same_partition(model.labels, [1, 1, 1, 1, 0, 0, 0, 0])
+    end
+
+    test "disconnected graph: two separate cliques are split (precomputed)" do
+      affinity =
+        Nx.tensor(
+          [
+            [1.0, 0.9, 0.8, 0.0, 0.0, 0.0],
+            [0.9, 1.0, 0.85, 0.0, 0.0, 0.0],
+            [0.8, 0.85, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.7, 0.6],
+            [0.0, 0.0, 0.0, 0.7, 1.0, 0.75],
+            [0.0, 0.0, 0.0, 0.6, 0.75, 1.0]
+          ],
+          type: :f64
+        )
+
+      model =
+        SpectralClustering.fit(affinity, num_clusters: 2, affinity: :precomputed, key: key())
+
+      assert_same_partition(model.labels, [0, 0, 0, 1, 1, 1])
+    end
+
+    test "isolated vertex gets its own cluster, matching sklearn (precomputed)" do
+      # Node 4 has no edges (all off-diagonal affinities are 0). Its Laplacian
+      # diagonal is set to 1 (as scikit-learn's `_set_diag` does), so it does not
+      # produce a spurious zero eigenvalue nor a NaN.
+      affinity =
+        Nx.tensor(
+          [
+            [1.0, 0.9, 0.0, 0.0, 0.0],
+            [0.9, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.85, 0.0],
+            [0.0, 0.0, 0.85, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0]
+          ],
+          type: :f64
+        )
+
+      model =
+        SpectralClustering.fit(affinity, num_clusters: 3, affinity: :precomputed, key: key())
+
+      assert_same_partition(model.labels, [0, 0, 1, 1, 2])
+      refute model.embedding |> Nx.is_nan() |> Nx.any() |> Nx.to_number() == 1
+    end
+
+    test "non-convex clusters: two nested half-moons are separated" do
+      # k-means alone cannot separate these two arcs; spectral clustering can.
+      outer =
+        for i <- 0..9 do
+          angle = :math.pi() * i / 9
+          [:math.cos(angle), :math.sin(angle)]
+        end
+
+      inner =
+        for i <- 0..9 do
+          angle = :math.pi() * i / 9
+          [1.0 - :math.cos(angle), 0.5 - :math.sin(angle)]
+        end
+
+      x = Nx.tensor(outer ++ inner, type: :f64)
+      model = SpectralClustering.fit(x, num_clusters: 2, gamma: 20.0, key: key())
+
+      expected = List.duplicate(0, 10) ++ List.duplicate(1, 10)
+      assert_same_partition(model.labels, expected)
+    end
+  end
+
+  describe "properties" do
+    test "returns f32 embedding and integer labels for f32 input" do
+      x = Nx.tensor([[0.0, 0.0], [0.1, 0.1], [3.0, 3.0], [3.1, 3.1]])
+      model = SpectralClustering.fit(x, num_clusters: 2, key: key())
+
+      assert Nx.type(model.embedding) == {:f, 32}
+      assert Nx.type(model.labels) == {:s, 32}
+      assert Nx.shape(model.labels) == {4}
+      assert Nx.shape(model.embedding) == {4, 2}
+    end
+
+    test "works inside jit" do
+      x =
+        Nx.tensor(
+          [
+            [0.0, 0.0],
+            [0.3, 0.2],
+            [0.2, 0.4],
+            [0.4, 0.1],
+            [1.5, 1.4],
+            [1.7, 1.6],
+            [1.6, 1.8],
+            [1.8, 1.5]
+          ],
+          type: :f64
+        )
+
+      k = key()
+      direct = SpectralClustering.fit(x, num_clusters: 2, key: k)
+
+      jitted =
+        Nx.Defn.jit_apply(
+          &SpectralClustering.fit(&1, num_clusters: 2, key: k),
+          [x]
+        )
+
+      assert Nx.to_flat_list(jitted.labels) == Nx.to_flat_list(direct.labels)
+      assert_all_close(jitted.embedding, direct.embedding, atol: 1.0e-12)
+    end
+
+    test "num_clusters == num_samples assigns every point its own cluster" do
+      x = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], type: :f64)
+      model = SpectralClustering.fit(x, num_clusters: 4, key: key())
+
+      assert model.labels |> Nx.sort() |> Nx.to_flat_list() == [0, 1, 2, 3]
+    end
+  end
+
+  describe "errors" do
+    test "raises for a non-rank-2 input" do
+      assert_raise ArgumentError,
+                   "expected input tensor to have shape {num_samples, num_features} or " <>
+                     "{num_samples, num_samples}, got tensor with shape: {3}",
+                   fn ->
+                     SpectralClustering.fit(Nx.tensor([1, 2, 3]), num_clusters: 2)
+                   end
+    end
+
+    test "raises for fewer than two samples" do
+      assert_raise ArgumentError, "expected at least 2 samples, got: 1", fn ->
+        SpectralClustering.fit(Nx.tensor([[3.0, 4.0]]), num_clusters: 1)
+      end
+    end
+
+    test "raises for a non-square precomputed affinity" do
+      assert_raise ArgumentError,
+                   "expected a square affinity matrix for affinity: :precomputed, " <>
+                     "got tensor with shape: {3, 2}",
+                   fn ->
+                     SpectralClustering.fit(Nx.broadcast(1.0, {3, 2}),
+                       num_clusters: 2,
+                       affinity: :precomputed
+                     )
+                   end
+    end
+
+    test "raises when num_clusters exceeds the number of samples" do
+      assert_raise ArgumentError,
+                   "invalid value for :num_clusters option: expected positive integer " <>
+                     "between 1 and 3, got: 4",
+                   fn ->
+                     SpectralClustering.fit(Nx.broadcast(1.0, {3, 2}), num_clusters: 4)
+                   end
+    end
+  end
+end


### PR DESCRIPTION
Add spectral clustering

Implements Scholar.Cluster.SpectralClustering via the normalized graph
Laplacian. The affinity matrix is built with an RBF kernel (gamma
configurable) or accepted as precomputed. Self-loops are discarded before
computing degrees, matching scipy's csgraph convention. Isolated vertices
keep a unit diagonal, matching scikit-learn's _set_diag behavior.

The spectral embedding takes the k eigenvectors of the smallest eigenvalues
of the Laplacian (eigh output is not sorted, so an explicit argsort is
needed), rescales them as u = D^-1/2 v per the relaxed Ncut formulation,
and applies a deterministic sign flip. K-means then runs on this embedding.

The struct exposes both labels and the embedding itself.

Related to #135.