### PR TITLE
Fix mean Tweedie deviance for power outside 0, 1 and 2

### DIFF
--- a/lib/scholar/metrics/regression.ex
+++ b/lib/scholar/metrics/regression.ex
@@ -275,11 +275,9 @@ defmodule Scholar.Metrics.Regression do
       cond do
         power < 0 ->
           2 *
-            (
-              Nx.pow(max(y_true, 0), 2 - power) / ((1 - power) * (2 - power))
-              -y_true * Nx.pow(y_pred, 1 - power) / (1 - power)
-              +Nx.pow(y_pred, 2 - power) / (2 - power)
-            )
+            (Nx.pow(max(y_true, 0), 2 - power) / ((1 - power) * (2 - power)) -
+               y_true * Nx.pow(y_pred, 1 - power) / (1 - power) +
+               Nx.pow(y_pred, 2 - power) / (2 - power))
 
         # Normal distribution
         power == 0 ->
@@ -298,11 +296,9 @@ defmodule Scholar.Metrics.Regression do
         # power > 2 -> Stable distribution, with support on the positive reals
         true ->
           2 *
-            (
-              Nx.pow(y_true, 2 - power) / ((1 - power) * (2 - power))
-              -y_true * Nx.pow(y_pred, 1 - power) / (1 - power)
-              +Nx.pow(y_pred, 2 - power) / (2 - power)
-            )
+            (Nx.pow(y_true, 2 - power) / ((1 - power) * (2 - power)) -
+               y_true * Nx.pow(y_pred, 1 - power) / (1 - power) +
+               Nx.pow(y_pred, 2 - power) / (2 - power))
       end
 
     Nx.mean(deviance, axes: opts[:axes])

--- a/test/scholar/metrics/regression_test.exs
+++ b/test/scholar/metrics/regression_test.exs
@@ -56,7 +56,51 @@ defmodule Scholar.Metrics.RegressionTest do
     end
   end
 
+  describe "mean_tweedie_deviance/4" do
+    # Reference values from sklearn 1.6.1 mean_tweedie_deviance.
+    test "matches sklearn for power between 1 and 2" do
+      y_true = Nx.tensor([1.0, 2.0, 3.0, 4.0], type: :f64)
+      y_pred = Nx.tensor([1.5, 1.5, 3.5, 4.5], type: :f64)
+
+      deviance = Regression.mean_tweedie_deviance(y_true, y_pred, 1.5)
+      assert_all_close(deviance, Nx.tensor(0.08778531726769745, type: :f64))
+    end
+
+    test "matches sklearn for power greater than 2" do
+      y_true = Nx.tensor([1.0, 2.0, 3.0, 4.0], type: :f64)
+      y_pred = Nx.tensor([1.5, 1.5, 3.5, 4.5], type: :f64)
+
+      deviance = Regression.mean_tweedie_deviance(y_true, y_pred, 3)
+      assert_all_close(deviance, Nx.tensor(0.04413895187704714, type: :f64))
+    end
+
+    test "matches sklearn for negative power" do
+      y_true = Nx.tensor([1.0, 2.0, 3.0, 4.0], type: :f64)
+      y_pred = Nx.tensor([1.5, 1.5, 3.5, 4.5], type: :f64)
+
+      deviance = Regression.mean_tweedie_deviance(y_true, y_pred, -1)
+      assert_all_close(deviance, Nx.tensor(0.6666666666666652, type: :f64))
+    end
+
+    test "deviance is non-negative and zero for perfect predictions" do
+      y_true = Nx.tensor([1.0, 2.0, 3.0, 4.0], type: :f64)
+
+      for power <- [-1, 1.5, 3] do
+        deviance = Regression.mean_tweedie_deviance(y_true, y_true, power)
+        assert_all_close(deviance, Nx.tensor(0.0, type: :f64))
+      end
+    end
+  end
+
   describe "d2_tweedie_score/3" do
+    test "matches sklearn for power between 1 and 2" do
+      y_true = Nx.tensor([1.0, 2.0, 3.0, 4.0], type: :f64)
+      y_pred = Nx.tensor([1.5, 1.5, 3.5, 4.5], type: :f64)
+
+      d2 = Regression.d2_tweedie_score(y_true, y_pred, 1.5)
+      assert_all_close(d2, Nx.tensor(0.7538144334490452, type: :f64))
+    end
+
     test "equal R^2 when power is 0" do
       y_true = Nx.tensor([1, 1, 1, 1, 1, 2, 2, 1, 3, 1], type: :u32)
       y_pred = Nx.tensor([2, 2, 1, 1, 2, 2, 2, 1, 3, 1], type: :u32)


### PR DESCRIPTION
I was evaluating a regression model using `mean_tweedie_deviance` with power 1.5 (compound Poisson-gamma) and the deviance looked way off compared to what sklearn gave for the same predictions. Traced it down to the formula for power outside 0, 1 and 2: it was split across multiple lines with the minus and plus operators at the start of each line, which Elixir parses as separate expressions inside parentheses rather than a continued one, so only the last term was actually being returned. Same issue affected d2_tweedie_score.

Joined it into a single expression and added tests comparing against sklearn for power 1.5, 3 and -1, plus a check that deviance is 0 for perfect predictions.