### PR TITLE
Add linear discriminant analysis classifier

### DIFF
--- a/lib/scholar/discriminant_analysis/linear.ex
+++ b/lib/scholar/discriminant_analysis/linear.ex
@@ -1,0 +1,187 @@
+defmodule Scholar.DiscriminantAnalysis.Linear do
+  @moduledoc ~S"""
+  Linear Discriminant Analysis (LDA) for classification.
+
+  LDA fits a Gaussian density to each class, assuming that all classes share the
+  same covariance matrix. The shared covariance leads to a linear decision
+  boundary between every pair of classes. For a sample $x$ the score of class $k$
+  is
+
+  $$ \delta\_{k}(x) = x^{T} \Sigma^{-1} \mu\_{k} - \frac{1}{2} \mu\_{k}^{T} \Sigma^{-1} \mu\_{k} + \log \pi\_{k} $$
+
+  where $\mu\_{k}$ is the class mean, $\pi\_{k}$ the class prior and $\Sigma$ the
+  pooled within-class covariance. The predicted class is the one with the
+  highest score.
+
+  The pooled covariance is assumed to be invertible, which holds when the number
+  of samples is larger than the number of features and no feature is a linear
+  combination of the others.
+
+  Reference:
+
+  * [1] - [The Elements of Statistical Learning, Hastie, Tibshirani & Friedman, Section 4.3](https://hastie.su.domains/ElemStatLearn/)
+  """
+  import Nx.Defn
+  import Scholar.Shared
+
+  @derive {Nx.Container, containers: [:coefficients, :intercept, :means, :priors, :classes]}
+  defstruct [:coefficients, :intercept, :means, :priors, :classes]
+
+  opts_schema = [
+    num_classes: [
+      type: :pos_integer,
+      required: true,
+      doc:
+        "Number of different classes used in training. Labels must be integers in `[0, num_classes)`."
+    ]
+  ]
+
+  @opts_schema NimbleOptions.new!(opts_schema)
+
+  @doc """
+  Fits a Linear Discriminant Analysis model for sample inputs `x` and target
+  labels `y`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  ## Return Values
+
+  The function returns a struct with the following parameters:
+
+    * `:coefficients` - Weight vector of each class, shape `{num_classes, num_features}`.
+
+    * `:intercept` - Intercept term of each class, shape `{num_classes}`.
+
+    * `:means` - Class-wise mean of the samples, shape `{num_classes, num_features}`.
+
+    * `:priors` - Class prior probabilities, shape `{num_classes}`.
+
+    * `:classes` - Labels seen during fit, shape `{num_classes}`.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Linear.fit(x, y, num_classes: 2)
+      iex> Scholar.DiscriminantAnalysis.Linear.predict(model, Nx.tensor([[-1.5, -1.5], [1.5, 1.5]]))
+      #Nx.Tensor<
+        s32[2]
+        [0, 1]
+      >
+  """
+  deftransform fit(x, y, opts \\ []) do
+    if Nx.rank(x) != 2 do
+      raise ArgumentError,
+            "expected x to have shape {num_samples, num_features}, " <>
+              "got tensor with shape: #{inspect(Nx.shape(x))}"
+    end
+
+    if Nx.rank(y) != 1 do
+      raise ArgumentError,
+            "expected y to have shape {num_samples}, " <>
+              "got tensor with shape: #{inspect(Nx.shape(y))}"
+    end
+
+    if Nx.axis_size(x, 0) != Nx.axis_size(y, 0) do
+      raise ArgumentError,
+            "expected x and y to have the same number of samples, " <>
+              "got #{Nx.axis_size(x, 0)} and #{Nx.axis_size(y, 0)}"
+    end
+
+    opts = NimbleOptions.validate!(opts, @opts_schema)
+    fit_n(x, y, opts)
+  end
+
+  defnp fit_n(x, y, opts) do
+    x = to_float(x)
+    num_classes = opts[:num_classes]
+    {num_samples, _num_features} = Nx.shape(x)
+    classes = Nx.iota({num_classes})
+
+    one_hot = (Nx.new_axis(y, 1) == Nx.new_axis(classes, 0)) |> Nx.as_type(Nx.type(x))
+    class_count = Nx.sum(one_hot, axes: [0])
+    priors = class_count / num_samples
+    means = Nx.dot(one_hot, [0], x, [0]) / Nx.new_axis(class_count, 1)
+    xbar = Nx.dot(priors, means)
+
+    # Pooled within-class covariance: center each sample by its class mean.
+    centered = x - Nx.take(means, y, axis: 0)
+    covariance = Nx.dot(centered, [0], centered, [0]) / (num_samples - num_classes)
+
+    centered_means = means - xbar
+    coefficients = Nx.LinAlg.solve(covariance, Nx.transpose(centered_means)) |> Nx.transpose()
+
+    intercept =
+      -0.5 * Nx.sum(coefficients * centered_means, axes: [1]) + Nx.log(priors) -
+        Nx.dot(coefficients, xbar)
+
+    %__MODULE__{
+      coefficients: coefficients,
+      intercept: intercept,
+      means: means,
+      priors: priors,
+      classes: classes
+    }
+  end
+
+  @doc """
+  Computes the linear discriminant scores of each class for samples `x`.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Linear.fit(x, y, num_classes: 2)
+      iex> scores = Scholar.DiscriminantAnalysis.Linear.decision_function(model, Nx.tensor([[1.5, 1.5]]))
+      iex> Nx.shape(scores)
+      {1, 2}
+  """
+  defn decision_function(%__MODULE__{coefficients: coefficients, intercept: intercept}, x) do
+    x = to_float(x)
+    Nx.dot(x, [1], coefficients, [1]) + intercept
+  end
+
+  @doc """
+  Predicts the class of each sample in `x`.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Linear.fit(x, y, num_classes: 2)
+      iex> Scholar.DiscriminantAnalysis.Linear.predict(model, Nx.tensor([[-1.5, -1.5], [1.5, 1.5]]))
+      #Nx.Tensor<
+        s32[2]
+        [0, 1]
+      >
+  """
+  defn predict(%__MODULE__{classes: classes} = model, x) do
+    scores = decision_function(model, x)
+    Nx.take(classes, Nx.argmax(scores, axis: 1))
+  end
+
+  @doc """
+  Estimates class probabilities for samples `x` by applying a softmax to the
+  discriminant scores.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Linear.fit(x, y, num_classes: 2)
+      iex> probs = Scholar.DiscriminantAnalysis.Linear.predict_probability(model, Nx.tensor([[1.5, 1.5]]))
+      iex> Nx.sum(probs) |> Nx.round()
+      #Nx.Tensor<
+        f32
+        1.0
+      >
+  """
+  defn predict_probability(%__MODULE__{} = model, x) do
+    scores = decision_function(model, x)
+    scores = scores - Nx.reduce_max(scores, axes: [1], keep_axes: true)
+    exp = Nx.exp(scores)
+    exp / Nx.sum(exp, axes: [1], keep_axes: true)
+  end
+end

--- a/lib/scholar/discriminant_analysis/linear.ex
+++ b/lib/scholar/discriminant_analysis/linear.ex
@@ -13,6 +13,11 @@ defmodule Scholar.DiscriminantAnalysis.Linear do
   pooled within-class covariance. The predicted class is the one with the
   highest score.
 
+  The scores are computed around the overall mean $\bar{x} = \sum\_{k} \pi\_{k}
+  \mu\_{k}$ (as scikit-learn's `svd` solver does), so `decision_function`
+  differs from the expression above by a term that is constant across classes.
+  That term cancels in `predict` and `predict_probability`.
+
   The pooled covariance is assumed to be invertible, which holds when the number
   of samples is larger than the number of features and no feature is a linear
   combination of the others.

--- a/lib/scholar/discriminant_analysis/linear.ex
+++ b/lib/scholar/discriminant_analysis/linear.ex
@@ -29,8 +29,8 @@ defmodule Scholar.DiscriminantAnalysis.Linear do
   import Nx.Defn
   import Scholar.Shared
 
-  @derive {Nx.Container, containers: [:coefficients, :intercept, :means, :priors, :classes]}
-  defstruct [:coefficients, :intercept, :means, :priors, :classes]
+  @derive {Nx.Container, containers: [:coefficients, :intercept, :means, :priors]}
+  defstruct [:coefficients, :intercept, :means, :priors]
 
   opts_schema = [
     num_classes: [
@@ -62,8 +62,6 @@ defmodule Scholar.DiscriminantAnalysis.Linear do
     * `:means` - Class-wise mean of the samples, shape `{num_classes, num_features}`.
 
     * `:priors` - Class prior probabilities, shape `{num_classes}`.
-
-    * `:classes` - Labels seen during fit, shape `{num_classes}`.
 
   ## Examples
 
@@ -126,8 +124,7 @@ defmodule Scholar.DiscriminantAnalysis.Linear do
       coefficients: coefficients,
       intercept: intercept,
       means: means,
-      priors: priors,
-      classes: classes
+      priors: priors
     }
   end
 
@@ -162,9 +159,9 @@ defmodule Scholar.DiscriminantAnalysis.Linear do
         [0, 1]
       >
   """
-  defn predict(%__MODULE__{classes: classes} = model, x) do
+  defn predict(%__MODULE__{} = model, x) do
     scores = decision_function(model, x)
-    Nx.take(classes, Nx.argmax(scores, axis: 1))
+    Nx.argmax(scores, axis: 1)
   end
 
   @doc """
@@ -185,7 +182,7 @@ defmodule Scholar.DiscriminantAnalysis.Linear do
   """
   defn predict_probability(%__MODULE__{} = model, x) do
     scores = decision_function(model, x)
-    scores = scores - Nx.reduce_max(scores, axes: [1], keep_axes: true)
+    scores = scores - stop_grad(Nx.reduce_max(scores, axes: [1], keep_axes: true))
     exp = Nx.exp(scores)
     exp / Nx.sum(exp, axes: [1], keep_axes: true)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -74,6 +74,7 @@ defmodule Scholar.MixProject do
           Scholar.Cluster.KMeans,
           Scholar.Decomposition.KernelPCA,
           Scholar.Decomposition.PCA,
+          Scholar.DiscriminantAnalysis.Linear,
           Scholar.Integrate,
           Scholar.Interpolation.BezierSpline,
           Scholar.Interpolation.CubicSpline,

--- a/test/scholar/discriminant_analysis/linear_test.exs
+++ b/test/scholar/discriminant_analysis/linear_test.exs
@@ -128,6 +128,68 @@ defmodule Scholar.DiscriminantAnalysis.LinearTest do
       probs = Linear.predict_probability(model, three_class_test_points())
       assert_all_close(probs, expected, atol: 1.0e-6)
     end
+
+    # Unequal class sizes exercise the interaction between the prior term and the
+    # (num_samples - num_classes) covariance normalization, which balanced
+    # classes do not.
+    test "coefficients, intercept and decision_function with unbalanced classes (f64)" do
+      x =
+        Nx.tensor(
+          [
+            [0.0, 0.0],
+            [0.5, 0.2],
+            [0.2, 0.4],
+            [0.1, 0.1],
+            [0.3, 0.0],
+            [0.0, 0.3],
+            [5.0, 5.0],
+            [5.2, 4.8],
+            [4.8, 5.1],
+            [10.0, 0.0],
+            [10.2, 0.3]
+          ],
+          type: :f64
+        )
+
+      y = Nx.tensor([0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2])
+      model = Linear.fit(x, y, num_classes: 3)
+
+      assert_all_close(
+        model.priors,
+        Nx.tensor([6 / 11, 3 / 11, 2 / 11], type: :f64)
+      )
+
+      expected_coef =
+        Nx.tensor(
+          [
+            [-90.99560744104983, -55.87429195011562],
+            [57.705113660897624, 130.21319023823452],
+            [186.42915183180307, -27.696909507004875]
+          ],
+          type: :f64
+        )
+
+      expected_intercept =
+        Nx.tensor([203.67786828506502, -660.0225187014742, -1228.3078001516808], type: :f64)
+
+      expected_decision =
+        Nx.tensor(
+          [
+            [159.61689846771537, -603.6470275317345, -1180.6881274542413],
+            [-530.6716286707622, 279.56900079418654, -434.6465885276898],
+            [-711.8656353204449, -69.95006306867447, 633.2140272156494],
+            [-163.4968801928486, -190.2267589536438, -831.4771943396853]
+          ],
+          type: :f64
+        )
+
+      assert_all_close(model.coefficients, expected_coef, atol: 1.0e-6)
+      assert_all_close(model.intercept, expected_intercept, atol: 1.0e-6)
+
+      decision = Linear.decision_function(model, three_class_test_points())
+      assert_all_close(decision, expected_decision, atol: 1.0e-6)
+      assert Nx.to_flat_list(Linear.predict(model, three_class_test_points())) == [0, 1, 2, 0]
+    end
   end
 
   describe "properties" do

--- a/test/scholar/discriminant_analysis/linear_test.exs
+++ b/test/scholar/discriminant_analysis/linear_test.exs
@@ -1,0 +1,202 @@
+defmodule Scholar.DiscriminantAnalysis.LinearTest do
+  use Scholar.Case, async: true
+
+  alias Scholar.DiscriminantAnalysis.Linear
+
+  doctest Linear
+
+  # Three well-separated classes in 2D. Reference values (coefficients,
+  # intercept, decision_function and predict_proba) come from scikit-learn
+  # 1.6.1 LinearDiscriminantAnalysis(solver="svd").
+  defp three_class do
+    x =
+      Nx.tensor(
+        [
+          [0.0, 0.0],
+          [0.5, 0.2],
+          [0.2, 0.4],
+          [0.1, 0.1],
+          [5.0, 5.0],
+          [5.2, 4.8],
+          [4.8, 5.1],
+          [5.1, 4.9],
+          [10.0, 0.0],
+          [10.2, 0.3],
+          [9.8, 0.1],
+          [10.1, 0.2]
+        ],
+        type: :f64
+      )
+
+    y = Nx.tensor([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])
+    {x, y}
+  end
+
+  defp three_class_test_points do
+    Nx.tensor([[0.3, 0.3], [5.0, 5.0], [10.0, 0.1], [2.5, 2.5]], type: :f64)
+  end
+
+  describe "fit and predict" do
+    test "separates three classes" do
+      {x, y} = three_class()
+      model = Linear.fit(x, y, num_classes: 3)
+
+      preds = Linear.predict(model, three_class_test_points())
+      assert Nx.to_flat_list(preds) == [0, 1, 2, 0]
+    end
+
+    test "separates two classes" do
+      x =
+        Nx.tensor([
+          [-2.0, -1.0],
+          [-1.0, -1.0],
+          [-1.0, -2.0],
+          [1.0, 1.0],
+          [1.0, 2.0],
+          [2.0, 1.0]
+        ])
+
+      y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      model = Linear.fit(x, y, num_classes: 2)
+
+      assert Nx.to_flat_list(Linear.predict(model, x)) == [0, 0, 0, 1, 1, 1]
+    end
+
+    test "recovers the fitted parameters" do
+      {x, y} = three_class()
+      model = Linear.fit(x, y, num_classes: 3)
+
+      assert Nx.shape(model.coefficients) == {3, 2}
+      assert Nx.shape(model.intercept) == {3}
+      assert Nx.shape(model.means) == {3, 2}
+      assert_all_close(model.priors, Nx.tensor([1 / 3, 1 / 3, 1 / 3], type: :f64))
+    end
+  end
+
+  describe "matches scikit-learn" do
+    test "coefficients, intercept and decision_function (f64)" do
+      {x, y} = three_class()
+      model = Linear.fit(x, y, num_classes: 3)
+
+      expected_coef =
+        Nx.tensor(
+          [
+            [-134.33268858800787, -54.50676982591884],
+            [-16.508704061895486, 155.8413926499033],
+            [150.8413926499034, -101.33462282398445]
+          ],
+          type: :f64
+        )
+
+      expected_intercept =
+        Nx.tensor([406.45345089637414, -440.3788750223887, -1043.8895133202616], type: :f64)
+
+      expected_decision =
+        Nx.tensor(
+          [
+            [349.80161337219613, -398.57906844598637, -1029.0374823724858],
+            [-537.7438411732594, 256.2845679176504, -796.3556641906669],
+            [-942.3241119662964, -589.8817763763532, 454.3909508963741],
+            [-65.6451951384426, -92.04715355236914, -920.1225887554642]
+          ],
+          type: :f64
+        )
+
+      assert Nx.type(model.coefficients) == {:f, 64}
+      assert_all_close(model.coefficients, expected_coef, atol: 1.0e-6)
+      assert_all_close(model.intercept, expected_intercept, atol: 1.0e-6)
+
+      decision = Linear.decision_function(model, three_class_test_points())
+      assert_all_close(decision, expected_decision, atol: 1.0e-6)
+    end
+
+    test "predict_probability (f64)" do
+      {x, y} = three_class()
+      model = Linear.fit(x, y, num_classes: 3)
+
+      expected =
+        Nx.tensor(
+          [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.9999999999965821, 3.4180243270357275e-12, 0.0]
+          ],
+          type: :f64
+        )
+
+      probs = Linear.predict_probability(model, three_class_test_points())
+      assert_all_close(probs, expected, atol: 1.0e-6)
+    end
+  end
+
+  describe "properties" do
+    test "keeps f64 through the model" do
+      {x, y} = three_class()
+      model = Linear.fit(x, y, num_classes: 3)
+      assert Nx.type(model.coefficients) == {:f, 64}
+      assert Nx.type(model.intercept) == {:f, 64}
+    end
+
+    test "casts integer input to f32" do
+      x = Nx.tensor([[0, 0], [1, 0], [8, 8], [9, 9]])
+      y = Nx.tensor([0, 0, 1, 1])
+      model = Linear.fit(x, y, num_classes: 2)
+      assert Nx.type(model.coefficients) == {:f, 32}
+      assert Nx.to_flat_list(Linear.predict(model, x)) == [0, 0, 1, 1]
+    end
+
+    test "works inside jit" do
+      {x, y} = three_class()
+      xt = three_class_test_points()
+
+      direct = Linear.fit(x, y, num_classes: 3) |> Linear.predict(xt)
+
+      jitted =
+        Nx.Defn.jit_apply(
+          fn x, y, xt -> Linear.fit(x, y, num_classes: 3) |> Linear.predict(xt) end,
+          [x, y, xt]
+        )
+
+      assert Nx.to_flat_list(jitted) == Nx.to_flat_list(direct)
+    end
+  end
+
+  describe "errors" do
+    test "raises for a non-rank-2 x" do
+      assert_raise ArgumentError,
+                   "expected x to have shape {num_samples, num_features}, " <>
+                     "got tensor with shape: {3}",
+                   fn ->
+                     Linear.fit(Nx.tensor([1, 2, 3]), Nx.tensor([0, 1, 0]), num_classes: 2)
+                   end
+    end
+
+    test "raises for a non-rank-1 y" do
+      assert_raise ArgumentError,
+                   "expected y to have shape {num_samples}, " <>
+                     "got tensor with shape: {2, 1}",
+                   fn ->
+                     Linear.fit(Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), Nx.tensor([[0], [1]]),
+                       num_classes: 2
+                     )
+                   end
+    end
+
+    test "raises when x and y have different number of samples" do
+      assert_raise ArgumentError,
+                   "expected x and y to have the same number of samples, got 2 and 3",
+                   fn ->
+                     Linear.fit(Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), Nx.tensor([0, 1, 0]),
+                       num_classes: 2
+                     )
+                   end
+    end
+
+    test "raises when num_classes is missing" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Linear.fit(Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), Nx.tensor([0, 1]), [])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `Scholar.DiscriminantAnalysis.Linear`, the Linear Discriminant Analysis
classifier. Addresses the LDA item of #338.

LDA fits a Gaussian to each class under a shared within-class covariance,
which gives a linear decision boundary between every pair of classes. The
model exposes `fit/3`, `decision_function/2`, `predict/2` and
`predict_probability/2`, and stores `coefficients`, `intercept`, `means`,
`priors` and `classes`.

A few decisions worth calling out:

* The pooled within-class covariance is normalized by
  `num_samples - num_classes` and the scores are parameterized around the
  overall mean, matching scikit-learn's `svd` solver. That parameterization
  makes `decision_function` differ from the bare textbook formula by a
  class-constant term, which cancels in `predict` and `predict_probability`.
* The coefficients are obtained by solving the pooled covariance system
  directly (`Nx.LinAlg.solve`) rather than via a double SVD. This is
  algebraically equivalent for full-rank data and matches scikit-learn to
  about 1.0e-13, but it assumes an invertible covariance (documented). A
  singular covariance raises instead of silently returning garbage.
* `predict_probability` applies a softmax to the discriminant scores. For
  two classes this reduces exactly to scikit-learn's binary sigmoid.

## Verification

Results match `sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
(solver `svd`) for `coefficients`, `intercept`, `decision_function`,
`predict` and `predict_probability`, on balanced and unbalanced classes,
binary and multiclass, and 2 and 3 features, all to roughly 1.0e-13 in f64.
The reference values in the tests were generated with scikit-learn 1.6.1.