### PR TITLE
Fix KDTree pruning to test against the splitting node

### DIFF
--- a/lib/scholar/neighbors/kd_tree.ex
+++ b/lib/scholar/neighbors/kd_tree.ex
@@ -461,7 +461,7 @@ defmodule Scholar.Neighbors.KDTree do
                   if Nx.any(
                        metric.(
                          point[[coord_indicator]],
-                         data[[indices[right_child(node)], coord_indicator]]
+                         data[[indices[node], coord_indicator]]
                        ) <
                          distances
                      ) do
@@ -489,7 +489,7 @@ defmodule Scholar.Neighbors.KDTree do
                   if Nx.any(
                        metric.(
                          point[[coord_indicator]],
-                         data[[indices[left_child(node)], coord_indicator]]
+                         data[[indices[node], coord_indicator]]
                        ) <
                          distances
                      ) do

--- a/test/scholar/neighbors/kd_tree_test.exs
+++ b/test/scholar/neighbors/kd_tree_test.exs
@@ -130,5 +130,39 @@ defmodule Scholar.Neighbors.KDTreeTest do
         ])
       )
     end
+
+    test "agrees with brute-force search" do
+      for seed <- 1..10 do
+        key = Nx.Random.key(seed)
+        {x, key} = Nx.Random.uniform(key, 0.0, 10.0, shape: {12, 2}, type: :f64)
+        {x_pred, _} = Nx.Random.uniform(key, 0.0, 10.0, shape: {5, 2}, type: :f64)
+
+        kdtree = KDTree.fit(x, num_neighbors: 3)
+        {kd_indices, kd_distances} = KDTree.predict(kdtree, x_pred)
+
+        brute = Scholar.Neighbors.BruteKNN.fit(x, num_neighbors: 3)
+        {brute_indices, brute_distances} = Scholar.Neighbors.BruteKNN.predict(brute, x_pred)
+
+        assert Nx.to_list(kd_indices) == Nx.to_list(brute_indices)
+        assert_all_close(kd_distances, brute_distances)
+      end
+    end
+
+    test "agrees with brute-force search on other metrics" do
+      key = Nx.Random.key(42)
+      {x, key} = Nx.Random.uniform(key, 0.0, 10.0, shape: {30, 3}, type: :f64)
+      {x_pred, _} = Nx.Random.uniform(key, 0.0, 10.0, shape: {5, 3}, type: :f64)
+
+      for metric <- [{:minkowski, 1}, {:minkowski, :infinity}] do
+        kdtree = KDTree.fit(x, num_neighbors: 3, metric: metric)
+        {kd_indices, kd_distances} = KDTree.predict(kdtree, x_pred)
+
+        brute = Scholar.Neighbors.BruteKNN.fit(x, num_neighbors: 3, metric: metric)
+        {brute_indices, brute_distances} = Scholar.Neighbors.BruteKNN.predict(brute, x_pred)
+
+        assert Nx.to_list(kd_indices) == Nx.to_list(brute_indices)
+        assert_all_close(kd_distances, brute_distances)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #342.

The backtracking step in `predict_n` decided whether to visit the sibling subtree by measuring the distance from the query to the child node's point along the split axis, instead of to the splitting hyperplane of the current node. Since the child lies inside the subtree, this overestimates the minimum possible distance and prunes subtrees that still contain closer points. On random 12x2 datasets with k=3, more than half of the queries disagreed with brute-force search.

The fix uses `indices[node]`, the point defining the cut, in both pruning tests.

Checked against `BruteKNN` across dimensions, k, and metrics (Minkowski p=1,2,3 and Chebyshev), and against scikit-learn's kd_tree. Added two regression tests comparing with brute force.