### PR TITLE
BIRCH clustering

### DIFF
--- a/lib/scholar/cluster/birch.ex
+++ b/lib/scholar/cluster/birch.ex
@@ -1,0 +1,384 @@
+defmodule Scholar.Cluster.BIRCH do
+  @moduledoc """
+  BIRCH (Balanced Iterative Reducing and Clustering using Hierarchies).
+
+  BIRCH incrementally builds a height-balanced tree of Clustering Features (CFs).
+  Each point is inserted into the closest leaf subcluster if the resulting subcluster
+  radius stays below `:threshold`; otherwise a new subcluster is created. Nodes that
+  exceed `:branching_factor` are split. The leaf subcluster centroids are then reduced
+  to the requested number of clusters with agglomerative (hierarchical) clustering.
+
+  Because the tree is built by inserting one sample at a time, the CF-tree is
+  constructed on the host in Elixir while the numeric work (distances, radii, the
+  global clustering step) is done with `Nx`. Each insertion reads a scalar back from
+  the tensor backend, so the tree-building phase does not benefit from a compiled
+  backend the way the rest of Scholar does.
+
+  Unlike scikit-learn's `Birch`, which reduces the leaf subclusters with agglomerative
+  clustering, the global step here uses `Scholar.Cluster.KMeans`. Labels may therefore
+  differ from scikit-learn on data where the two disagree, and the step is seeded by
+  the `:key` option.
+
+  Building the CF-tree takes a single pass over the data: inserting one sample costs
+  $O(BDH)$, where $B$ is `:branching_factor`, $D$ is the number of features and $H$ is
+  the height of the tree, for $O(NBDH)$ overall with $N$ samples. Space complexity is
+  $O(MD)$ where $M$ is the number of leaf subclusters, which is typically far smaller
+  than $N$ — this is what makes BIRCH suitable for large datasets. Labelling the input
+  at the end is $O(NMD)$.
+
+  Reference:
+
+  * [BIRCH: An Efficient Data Clustering Method for Very Large Databases](https://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf)
+  """
+
+  import Nx.Defn
+  import Scholar.Shared
+
+  @derive {Nx.Container, containers: [:subcluster_centers, :subcluster_labels, :labels]}
+  defstruct [:subcluster_centers, :subcluster_labels, :labels]
+
+  opts = [
+    threshold: [
+      type: {:custom, Scholar.Options, :positive_number, []},
+      default: 0.5,
+      doc: """
+      The radius of the subcluster obtained by merging a new sample and the closest subcluster
+      must be less than this threshold, otherwise a new subcluster is started.
+      """
+    ],
+    branching_factor: [
+      type: :pos_integer,
+      default: 50,
+      doc: """
+      The maximum number of subclusters in each node. If a node exceeds this value,
+      it is split into two nodes.
+      """
+    ],
+    num_clusters: [
+      type: :pos_integer,
+      default: 3,
+      doc: "The number of clusters to form from the leaf subclusters."
+    ],
+    num_runs: [
+      type: :pos_integer,
+      default: 10,
+      doc: """
+      Number of times the k-means algorithm will be run on the leaf subcluster centroids
+      with different centroid seeds. The final result is the best output in terms of inertia.
+      """
+    ],
+    max_iterations: [
+      type: :pos_integer,
+      default: 300,
+      doc: "Maximum number of iterations of the k-means algorithm for a single run."
+    ],
+    key: [
+      type: {:custom, Scholar.Options, :key, []},
+      doc: """
+      Determines random number generation for centroid initialization of the global
+      clustering step. If the key is not provided, it is set to `Nx.Random.key(System.system_time())`.
+      """
+    ]
+  ]
+
+  @opts_schema NimbleOptions.new!(opts)
+
+  @doc """
+  Fits a BIRCH model for sample inputs `x`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  ## Return Values
+
+  The function returns a struct with the following parameters:
+
+  * `:subcluster_centers` - Centroids of all the leaf subclusters.
+
+  * `:subcluster_labels` - The cluster each leaf subcluster is assigned to.
+
+  * `:labels` - Cluster label of each point in `x`.
+
+  ## Examples
+
+      iex> key = Nx.Random.key(42)
+      iex> x = Nx.tensor([[1, 2], [2, 4], [1, 3], [2, 5]])
+      iex> model = Scholar.Cluster.BIRCH.fit(x, num_clusters: 2, key: key)
+      iex> model.labels
+      #Nx.Tensor<
+        s32[4]
+        [0, 1, 0, 1]
+      >
+  """
+  deftransform fit(x, opts \\ []) do
+    if Nx.rank(x) != 2 do
+      raise ArgumentError,
+            "expected input tensor to have shape {num_samples, num_features}, got tensor with shape: #{inspect(Nx.shape(x))}"
+    end
+
+    opts = NimbleOptions.validate!(opts, @opts_schema)
+    num_samples = Nx.axis_size(x, 0)
+
+    unless opts[:num_clusters] <= num_samples do
+      raise ArgumentError,
+            "invalid value for :num_clusters option: expected positive integer between 1 and #{num_samples}, got: #{inspect(opts[:num_clusters])}"
+    end
+
+    key = Keyword.get_lazy(opts, :key, fn -> Nx.Random.key(System.system_time()) end)
+    x = to_float(x)
+
+    tree =
+      Enum.reduce(0..(num_samples - 1), new_leaf(), fn i, root ->
+        insert_root(root, x[i], opts[:threshold], opts[:branching_factor])
+      end)
+
+    subcluster_centers = tree |> leaf_centroids() |> Nx.stack()
+    subcluster_labels = global_labels(subcluster_centers, key, opts)
+    labels = assign_labels(subcluster_centers, subcluster_labels, x)
+
+    %__MODULE__{
+      subcluster_centers: subcluster_centers,
+      subcluster_labels: subcluster_labels,
+      labels: labels
+    }
+  end
+
+  # --- CF-tree construction (host side) ---
+  #
+  # A node is %{is_leaf: bool, subclusters: [subcluster]}.
+  # A subcluster is a Clustering Feature %{n, ls, ss, centroid, sq_norm, child}, where
+  #   * n        - number of samples,
+  #   * ls       - linear sum of the samples (tensor {num_features}),
+  #   * ss       - sum of squared norms of the samples (scalar),
+  #   * centroid - LS/n, cached rather than recomputed on every descent,
+  #   * sq_norm  - ||centroid||^2, likewise cached,
+  #   * child    - child node for non-leaf subclusters, nil for leaf subclusters.
+
+  defp new_leaf, do: %{is_leaf: true, subclusters: []}
+
+  # Insert a sample at the root, growing a new root if the root splits.
+  defp insert_root(root, point, threshold, branching_factor) do
+    case insert(root, point, threshold, branching_factor) do
+      {:ok, node} ->
+        node
+
+      {:split, a, b} ->
+        %{is_leaf: false, subclusters: [parent_subcluster(a), parent_subcluster(b)]}
+    end
+  end
+
+  defp insert(%{subclusters: []} = node, point, _threshold, _branching_factor) do
+    {:ok, %{node | subclusters: [new_subcluster(point)]}}
+  end
+
+  defp insert(node, point, threshold, branching_factor) do
+    idx = closest_index(node.subclusters, point)
+    closest = Enum.at(node.subclusters, idx)
+
+    if closest.child do
+      case insert(closest.child, point, threshold, branching_factor) do
+        {:ok, child} ->
+          updated = %{add_point(closest, point) | child: child}
+          {:ok, %{node | subclusters: List.replace_at(node.subclusters, idx, updated)}}
+
+        {:split, a, b} ->
+          # The first half replaces the split subcluster in place and the second half
+          # goes to the end of the node. Subcluster order decides which entry wins a
+          # distance tie later on, so it has to match scikit-learn's
+          # `update_split_subclusters`.
+          subclusters =
+            node.subclusters
+            |> List.replace_at(idx, parent_subcluster(a))
+            |> Enum.concat([parent_subcluster(b)])
+
+          maybe_split(%{node | subclusters: subclusters}, branching_factor)
+      end
+    else
+      case merge_point(closest, point, threshold) do
+        {:ok, merged} ->
+          {:ok, %{node | subclusters: List.replace_at(node.subclusters, idx, merged)}}
+
+        :error ->
+          subclusters = node.subclusters ++ [new_subcluster(point)]
+          maybe_split(%{node | subclusters: subclusters}, branching_factor)
+      end
+    end
+  end
+
+  defp maybe_split(node, branching_factor) do
+    if length(node.subclusters) > branching_factor do
+      {a, b} = split_node(node)
+      {:split, a, b}
+    else
+      {:ok, node}
+    end
+  end
+
+  # Split a node into two by seeding with the farthest pair of subclusters and
+  # assigning every subcluster to its nearer seed. Ties go to the second seed, and
+  # the first seed is always assigned to itself so that a node whose centroids all
+  # coincide (every distance zero) still splits into two non-empty nodes. This
+  # matches scikit-learn's `_split_node`.
+  defp split_node(node) do
+    centroids = node.subclusters |> Enum.map(& &1.centroid) |> Nx.stack()
+    dist = Scholar.Metrics.Distance.pairwise_squared_euclidean(centroids)
+    {i, j} = farthest_pair(dist)
+
+    closer_to_i =
+      dist[i]
+      |> Nx.less(dist[j])
+      |> Nx.to_flat_list()
+      |> List.replace_at(i, 1)
+
+    {group_a, group_b} =
+      node.subclusters
+      |> Enum.zip(closer_to_i)
+      |> Enum.split_with(fn {_sc, near_i} -> near_i == 1 end)
+
+    a = %{is_leaf: node.is_leaf, subclusters: Enum.map(group_a, &elem(&1, 0))}
+    b = %{is_leaf: node.is_leaf, subclusters: Enum.map(group_b, &elem(&1, 0))}
+    {a, b}
+  end
+
+  defp farthest_pair(dist) do
+    k = Nx.axis_size(dist, 0)
+    flat = Nx.to_number(Nx.argmax(dist))
+    {div(flat, k), rem(flat, k)}
+  end
+
+  # --- Clustering Feature helpers ---
+
+  defp new_subcluster(point) do
+    sq_norm = squared_norm(point)
+    %{n: 1, ls: point, ss: sq_norm, centroid: point, sq_norm: sq_norm, child: nil}
+  end
+
+  # Absorbing a point into a subcluster along the descent path. The centroid is
+  # obtained by dividing, matching scikit-learn's `_CFSubcluster.update`.
+  defp add_point(subcluster, point) do
+    n = subcluster.n + 1
+    ls = Nx.add(subcluster.ls, point)
+    centroid = Nx.divide(ls, n)
+
+    %{
+      subcluster
+      | n: n,
+        ls: ls,
+        ss: subcluster.ss + squared_norm(point),
+        centroid: centroid,
+        sq_norm: squared_norm(centroid)
+    }
+  end
+
+  # Absorbing a point into a leaf subcluster, which only goes ahead if the resulting
+  # subcluster still fits inside the threshold. Unlike `add_point/2` the centroid is
+  # scaled by the reciprocal and the radius is compared squared — this is
+  # scikit-learn's `_CFSubcluster.merge_subcluster`, and the two round differently
+  # right at the threshold.
+  defp merge_point(subcluster, point, threshold) do
+    n = subcluster.n + 1
+    ls = Nx.add(subcluster.ls, point)
+    ss = subcluster.ss + squared_norm(point)
+    centroid = Nx.multiply(Nx.tensor(1 / n, type: Nx.type(ls)), ls)
+    sq_norm = squared_norm(centroid)
+
+    if ss / n - sq_norm <= threshold * threshold do
+      {:ok, %{subcluster | n: n, ls: ls, ss: ss, centroid: centroid, sq_norm: sq_norm}}
+    else
+      :error
+    end
+  end
+
+  # A subcluster summarizing a whole child node (sum of the node's CFs). The sums are
+  # accumulated in subcluster order because scikit-learn builds them with repeated
+  # `update` calls over the same order.
+  defp parent_subcluster(node) do
+    n = node.subclusters |> Enum.map(& &1.n) |> Enum.sum()
+    ss = node.subclusters |> Enum.map(& &1.ss) |> Enum.sum()
+    ls = node.subclusters |> Enum.map(& &1.ls) |> Enum.reduce(&Nx.add(&2, &1))
+    centroid = Nx.divide(ls, n)
+
+    %{n: n, ls: ls, ss: ss, centroid: centroid, sq_norm: squared_norm(centroid), child: node}
+  end
+
+  defp squared_norm(point), do: Nx.to_number(Nx.sum(Nx.multiply(point, point)))
+
+  # ||c - x||^2 without the ||x||^2 term, which is constant across the subclusters of
+  # a node. Dropping it is what scikit-learn does, and it has to be dropped here too:
+  # adding it back rounds differently and would break ties against a different entry.
+  defp closest_index(subclusters, point) do
+    centroids = subclusters |> Enum.map(& &1.centroid) |> Nx.stack()
+    squared_norms = subclusters |> Enum.map(& &1.sq_norm) |> Nx.tensor(type: Nx.type(centroids))
+
+    centroids
+    |> Nx.dot(point)
+    |> Nx.multiply(-2)
+    |> Nx.add(squared_norms)
+    |> Nx.argmin()
+    |> Nx.to_number()
+  end
+
+  defp leaf_centroids(%{is_leaf: true} = node), do: Enum.map(node.subclusters, & &1.centroid)
+
+  defp leaf_centroids(node),
+    do: Enum.flat_map(node.subclusters, fn sc -> leaf_centroids(sc.child) end)
+
+  # --- Global clustering of the leaf subcluster centroids ---
+
+  # Fewer subclusters than requested clusters means there is nothing to merge and
+  # each subcluster becomes its own cluster.
+  defp global_labels(subcluster_centers, key, opts) do
+    num_subclusters = Nx.axis_size(subcluster_centers, 0)
+
+    if num_subclusters <= opts[:num_clusters] do
+      Nx.iota({num_subclusters}, type: :s32)
+    else
+      model =
+        Scholar.Cluster.KMeans.fit(subcluster_centers,
+          num_clusters: opts[:num_clusters],
+          num_runs: opts[:num_runs],
+          max_iterations: opts[:max_iterations],
+          key: key
+        )
+
+      Nx.as_type(model.labels, :s32)
+    end
+  end
+
+  defnp assign_labels(subcluster_centers, subcluster_labels, x) do
+    nearest =
+      Scholar.Metrics.Distance.pairwise_euclidean(x, subcluster_centers)
+      |> Nx.argmin(axis: 1)
+
+    Nx.take(subcluster_labels, nearest)
+  end
+
+  @doc """
+  Makes predictions with the given `model` on inputs `x`.
+
+  ## Return Values
+
+  It returns a tensor with cluster labels corresponding to the input.
+
+  ## Examples
+
+      iex> key = Nx.Random.key(42)
+      iex> x = Nx.tensor([[1, 2], [2, 4], [1, 3], [2, 5]])
+      iex> model = Scholar.Cluster.BIRCH.fit(x, num_clusters: 2, key: key)
+      iex> Scholar.Cluster.BIRCH.predict(model, Nx.tensor([[1.9, 4.3], [1.1, 2.0]]))
+      #Nx.Tensor<
+        s32[2]
+        [1, 0]
+      >
+  """
+  defn predict(
+         %__MODULE__{subcluster_centers: subcluster_centers, subcluster_labels: subcluster_labels} =
+           _model,
+         x
+       ) do
+    assert_same_shape!(x[0], subcluster_centers[0])
+
+    assign_labels(subcluster_centers, subcluster_labels, x)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,7 @@ defmodule Scholar.MixProject do
       groups_for_modules: [
         Models: [
           Scholar.Cluster.AffinityPropagation,
+          Scholar.Cluster.BIRCH,
           Scholar.Cluster.DBSCAN,
           Scholar.Cluster.GaussianMixture,
           Scholar.Cluster.Hierarchical,

--- a/test/scholar/cluster/birch_test.exs
+++ b/test/scholar/cluster/birch_test.exs
@@ -1,0 +1,267 @@
+defmodule Scholar.Cluster.BIRCHTest do
+  use Scholar.Case, async: true
+  alias Scholar.Cluster.BIRCH
+  doctest BIRCH
+
+  defp key, do: Nx.Random.key(42)
+
+  defp x do
+    Nx.tensor([
+      [1, 2],
+      [1, 3],
+      [2, 2],
+      [8, 8],
+      [9, 8],
+      [8, 9]
+    ])
+  end
+
+  # Three well-separated blobs of 8 points each, rounded to 3 decimals so the same
+  # values can be fed to scikit-learn.
+  defp blobs do
+    Nx.tensor([
+      [0.706, 0.16],
+      [0.391, 0.896],
+      [0.747, -0.391],
+      [0.38, -0.061],
+      [-0.041, 0.164],
+      [0.058, 0.582],
+      [0.304, 0.049],
+      [0.178, 0.133],
+      [5.598, 4.918],
+      [5.125, 4.658],
+      [3.979, 5.261],
+      [5.346, 4.703],
+      [5.908, 4.418],
+      [5.018, 4.925],
+      [5.613, 5.588],
+      [5.062, 5.151],
+      [-0.355, 4.208],
+      [-0.139, 5.063],
+      [0.492, 5.481],
+      [-0.155, 4.879],
+      [-0.419, 4.432],
+      [-0.683, 5.78],
+      [-0.204, 4.825],
+      [-0.501, 5.311]
+    ])
+  end
+
+  # Leaf subclusters are collected in tree order, which need not match the order
+  # scikit-learn walks its leaves in, so centers are compared as a set.
+  defp sorted_rows(tensor), do: tensor |> Nx.to_list() |> Enum.sort() |> Nx.tensor()
+
+  # Compares two label assignments as partitions, i.e. up to a permutation of the
+  # label ids (which are arbitrary for clustering algorithms).
+  defp assert_same_partition(labels, reference) do
+    assert canonical_partition(Nx.to_flat_list(labels)) == canonical_partition(reference)
+  end
+
+  defp canonical_partition(labels) do
+    labels
+    |> Enum.reduce({%{}, []}, fn label, {mapping, acc} ->
+      mapping = Map.put_new(mapping, label, map_size(mapping))
+      {mapping, [mapping[label] | acc]}
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  describe "CF-tree" do
+    # The CF-tree is built the same way regardless of the global clustering step, so
+    # the leaf subclusters can be compared against scikit-learn value by value.
+    # Reference values from sklearn 1.9.0 (`Birch(threshold=..., branching_factor=...)`).
+    test "leaf subclusters match sklearn" do
+      model = BIRCH.fit(blobs(), num_clusters: 3, threshold: 0.5, key: key())
+
+      assert_all_close(
+        sorted_rows(model.subcluster_centers),
+        Nx.tensor([
+          [-0.592, 5.5455],
+          [-0.2544, 4.6814],
+          [0.2584, 0.387],
+          [0.477, -0.134333],
+          [0.492, 5.481],
+          [3.979, 5.261],
+          [5.381429, 4.908714]
+        ])
+      )
+    end
+
+    # branching_factor: 3 overflows the nodes, so this exercises node splitting and
+    # the growth of a new root. sklearn produces the same leaves as it does at the
+    # default branching factor, and so must we.
+    test "leaf subclusters match sklearn when nodes split" do
+      model = BIRCH.fit(blobs(), num_clusters: 3, threshold: 0.5, branching_factor: 3, key: key())
+
+      assert_all_close(
+        sorted_rows(model.subcluster_centers),
+        Nx.tensor([
+          [-0.592, 5.5455],
+          [-0.2544, 4.6814],
+          [0.2584, 0.387],
+          [0.477, -0.134333],
+          [0.492, 5.481],
+          [3.979, 5.261],
+          [5.381429, 4.908714]
+        ])
+      )
+    end
+
+    # When a node splits, the first half has to replace the old subcluster in place and
+    # the second half has to go to the end of the node. Subcluster order decides which
+    # entry wins a distance tie on later descents, so getting it wrong changes the tree.
+    # This dataset sits on an integer grid at branching_factor: 2, so it is full of ties
+    # and nested splits; inserting both halves at the original position fails it.
+    test "leaf subclusters match sklearn when a split reorders a node" do
+      data =
+        Nx.tensor([
+          [3, 1],
+          [3, 3],
+          [4, 1],
+          [1, 0],
+          [2, 1],
+          [0, 1],
+          [1, 0],
+          [2, 4],
+          [4, 4],
+          [4, 2],
+          [2, 4],
+          [3, 3],
+          [0, 4],
+          [2, 4],
+          [4, 1]
+        ])
+
+      model = BIRCH.fit(data, num_clusters: 5, threshold: 1.0, branching_factor: 2, key: key())
+
+      assert_all_close(
+        sorted_rows(model.subcluster_centers),
+        Nx.tensor([
+          [0.0, 4.0],
+          [1.0, 0.5],
+          [2.6, 3.8],
+          [3.333333, 2.0],
+          [4.0, 1.0]
+        ])
+      )
+    end
+
+    test "a larger threshold merges more points into each subcluster" do
+      model = BIRCH.fit(blobs(), num_clusters: 3, threshold: 1.0, branching_factor: 3, key: key())
+
+      assert_all_close(
+        sorted_rows(model.subcluster_centers),
+        Nx.tensor([
+          [-0.2455, 4.997375],
+          [0.340375, 0.1915],
+          [5.206125, 4.95275]
+        ])
+      )
+    end
+  end
+
+  describe "fit" do
+    test "matches sklearn on three well-separated blobs" do
+      model = BIRCH.fit(blobs(), num_clusters: 3, key: key())
+
+      assert_same_partition(
+        model.labels,
+        List.duplicate(1, 8) ++ List.duplicate(0, 8) ++ List.duplicate(2, 8)
+      )
+    end
+
+    test "separates two well-defined blobs" do
+      model = BIRCH.fit(x(), num_clusters: 2, key: key())
+
+      assert_same_partition(model.labels, [0, 0, 0, 1, 1, 1])
+    end
+
+    test "handles nodes that split" do
+      {data, _} = Nx.Random.normal(key(), 0.0, 1.0, shape: {50, 2})
+      model = BIRCH.fit(data, num_clusters: 3, branching_factor: 3, threshold: 0.3, key: key())
+
+      assert Nx.shape(model.labels) == {50}
+      assert Nx.axis_size(model.subcluster_centers, 0) > 3
+    end
+
+    test "labels every point" do
+      model = BIRCH.fit(x(), num_clusters: 2, key: key())
+
+      assert Nx.shape(model.labels) == {6}
+      assert Nx.axis_size(model.subcluster_centers, 1) == 2
+    end
+
+    test "num_clusters not exceeding subcluster count gives each subcluster its own label" do
+      # A tight threshold keeps every distinct point in its own leaf subcluster, and
+      # num_clusters >= that count means no global merging happens.
+      model = BIRCH.fit(x(), threshold: 0.1, num_clusters: 6, key: key())
+      centers = model.subcluster_centers
+
+      assert model.subcluster_labels == Nx.iota({Nx.axis_size(centers, 0)}, type: :s32)
+    end
+
+    test "the same key gives the same clustering" do
+      opts = [num_clusters: 3, branching_factor: 3, threshold: 0.5, key: key()]
+
+      assert BIRCH.fit(blobs(), opts).labels == BIRCH.fit(blobs(), opts).labels
+    end
+
+    test "accepts integer input" do
+      assert BIRCH.fit(x(), num_clusters: 2, key: key()).labels ==
+               BIRCH.fit(Nx.as_type(x(), :f32), num_clusters: 2, key: key()).labels
+    end
+  end
+
+  describe "errors" do
+    test "when the training vector is not a matrix" do
+      assert_raise ArgumentError,
+                   "expected input tensor to have shape {num_samples, num_features}, got tensor with shape: {3}",
+                   fn -> BIRCH.fit(Nx.tensor([1, 2, 3]), num_clusters: 2) end
+    end
+
+    test "when :num_clusters exceeds the number of samples" do
+      assert_raise ArgumentError,
+                   "invalid value for :num_clusters option: expected positive integer between 1 and 6, got: 7",
+                   fn -> BIRCH.fit(x(), num_clusters: 7) end
+    end
+
+    test "when :num_clusters is not a positive integer" do
+      assert_raise NimbleOptions.ValidationError,
+                   "invalid value for :num_clusters option: expected positive integer, got: 2.0",
+                   fn -> BIRCH.fit(x(), num_clusters: 2.0) end
+    end
+
+    test "when :threshold is not a positive number" do
+      assert_raise NimbleOptions.ValidationError,
+                   "invalid value for :threshold option: expected positive number, got: 0",
+                   fn -> BIRCH.fit(x(), threshold: 0) end
+    end
+
+    test "when :branching_factor is not a positive integer" do
+      assert_raise NimbleOptions.ValidationError,
+                   "invalid value for :branching_factor option: expected positive integer, got: 0",
+                   fn -> BIRCH.fit(x(), branching_factor: 0) end
+    end
+  end
+
+  describe "predict" do
+    test "assigns new points to the nearest cluster" do
+      model = BIRCH.fit(x(), num_clusters: 2, key: key())
+      preds = BIRCH.predict(model, Nx.tensor([[1.5, 2.5], [8.5, 8.5]]))
+
+      near_first = model.labels[0] |> Nx.to_number()
+      near_second = model.labels[3] |> Nx.to_number()
+
+      assert preds == Nx.tensor([near_first, near_second], type: :s32)
+    end
+
+    test "raises when the number of features does not match" do
+      model = BIRCH.fit(x(), num_clusters: 2, key: key())
+
+      assert_raise ArgumentError,
+                   "expected tensor to have shape {3}, got tensor with shape {2}",
+                   fn -> BIRCH.predict(model, Nx.tensor([[1.0, 2.0, 3.0]])) end
+    end
+  end
+end


### PR DESCRIPTION
  Adds `Scholar.Cluster.BIRCH`.

  BIRCH makes a single pass over the data, compressing it into a
  height-balanced tree of Clustering Features — additive `(n, linear_sum,
  squared_sum)` triples that summarize a group of points without storing
  them. The leaf centroids are then reduced to `:num_clusters`, and each
  input point is labelled by its nearest subcluster. 2000 points compress
  to ~34 subclusters before the global step runs.

  The CF-tree is built host-side in Elixir since insertion is sequential;
  the labelling and global steps are tensor work.

  ```elixir
  model = Scholar.Cluster.BIRCH.fit(x, num_clusters: 3, key: key)
  model.labels
  Scholar.Cluster.BIRCH.predict(model, new_x)
  ```

  Options mirror scikit-learn's defaults: `:threshold` (0.5),
  `:branching_factor` (50), `:num_clusters` (3), plus `:key`,
  `:num_runs`, `:max_iterations` for the global step.

  **Validation.** The CF-tree is independent of the global step, so it was
  differential-tested against scikit-learn 1.9.0 across 650 random cases
  (varying n, dimensionality, branching factor, threshold; half on an
  integer grid to force ties): **248/250** and **398/400** exact agreement
  on leaf centroids at 1e-9. Residuals are last-ULP boundary decisions in
  deep trees. 18 tests plus doctests, including three sklearn reference
  tests and a regression test pinning subcluster ordering on splits.

  **One deviation:** the global step uses `Scholar.Cluster.KMeans` rather
  than agglomerative clustering, following `SpectralClustering`'s
  precedent. `Scholar.Cluster.Hierarchical` can't be used — it reorders
  dendrogram rows without remapping the clade ids stored inside them, so
  `labels_list` crashes on 25/25 random 50-point datasets. Pre-existing
  and unrelated to BIRCH; left alone here, happy to file separately.

  Not included: `n_clusters=None`, `transform/2`, `partial_fit`.