### PR TITLE
Add quadratic discriminant analysis classifier

### DIFF
--- a/lib/scholar/discriminant_analysis/quadratic.ex
+++ b/lib/scholar/discriminant_analysis/quadratic.ex
@@ -20,8 +20,22 @@ defmodule Scholar.DiscriminantAnalysis.Quadratic do
 
   Every class covariance is assumed to be invertible, which requires at least as
   many samples as features in each class and no feature being a linear
-  combination of the others. Use `:reg_param` to shrink the eigenvalues towards
-  one when that does not hold.
+  combination of the others. When that does not hold, a covariance is singular
+  and its smallest eigenvalues come out as zero, which the score then divides by.
+  Use `:reg_param` to shrink the eigenvalues towards one in that case.
+
+  Note that scikit-learn handles rank deficiency differently: it decomposes the
+  centered class data and keeps only `min(class_size, num_features)` components,
+  so it works in the subspace the class actually spans. This implementation keeps
+  all `num_features` directions and relies on `:reg_param` instead, so results
+  diverge from scikit-learn's for a class with fewer samples than features.
+
+  Forming the covariance squares its condition number, so features on wildly
+  different scales cost accuracy in the eigendecomposition well before the
+  matrix is singular. A compiled backend absorbs this, but the pure-Nx
+  eigendecomposition does not, and features spanning several orders of magnitude
+  can lose the smallest eigenvalues there entirely. Standardizing the features
+  beforehand, with `Scholar.Preprocessing.StandardScaler`, avoids it either way.
 
   Reference:
 
@@ -33,11 +47,13 @@ defmodule Scholar.DiscriminantAnalysis.Quadratic do
   @derive {Nx.Container, containers: [:means, :priors, :scalings, :rotations]}
   defstruct [:means, :priors, :scalings, :rotations]
 
-  # `Nx.LinAlg.eigh/2` defaults to `eps: 1.0e-4`, which leaves the eigenvalues
-  # about three digits short. QDA divides by them and takes their log, so the
-  # error is amplified rather than absorbed. Measured against LAPACK on the same
-  # f64 covariance, 1.0e-8 lands the eigenvalues within ~1.0e-7; tightening
-  # further makes it worse, since the iteration then runs into `:max_iter`.
+  # Only matters for the pure-Nx eigendecomposition, which compilers like EXLA
+  # replace with a native routine. There `Nx.LinAlg.eigh/2` runs a Jacobi
+  # iteration whose default `eps: 1.0e-4` leaves the eigenvalues about three
+  # digits short, and QDA divides by them and takes their log, so that error is
+  # amplified rather than absorbed. Measured against LAPACK on the same f64
+  # covariance, 1.0e-8 lands the eigenvalues within ~1.0e-7; tightening further
+  # makes it worse, since the iteration then runs into `:max_iter`.
   @eigh_eps 1.0e-8
 
   opts_schema = [
@@ -128,23 +144,32 @@ defmodule Scholar.DiscriminantAnalysis.Quadratic do
     priors = class_count / num_samples
     means = Nx.dot(one_hot, [0], x, [0]) / Nx.new_axis(class_count, 1)
 
-    # One covariance per class. Looping keeps the working set at O(num_samples *
-    # num_features); masking every class at once would need a
-    # {num_classes, num_samples, num_features} intermediate instead.
-    covariances =
+    # One covariance per class, decomposed as we go. Looping keeps the working
+    # set at O(num_samples * num_features); masking every class at once would
+    # need a {num_classes, num_samples, num_features} intermediate instead.
+    #
+    # The decomposition also has to happen one class at a time: as of Nx 0.9.2,
+    # `Nx.LinAlg.eigh/2` on a stack of matrices only decomposes the first one
+    # under EXLA and returns zeros for the rest.
+    scalings = Nx.broadcast(Nx.tensor(0, type: Nx.type(x)), {num_classes, num_features})
+
+    rotations =
       Nx.broadcast(Nx.tensor(0, type: Nx.type(x)), {num_classes, num_features, num_features})
 
-    {covariances, _} =
-      while {covariances, {x, one_hot, means, k = 0}}, k < num_classes do
+    {scalings, rotations, _} =
+      while {scalings, rotations, {x, one_hot, means, k = 0}}, k < num_classes do
         mask = Nx.new_axis(one_hot[[.., k]], 1)
         centered = (x - means[k]) * mask
         covariance = Nx.dot(centered, [0], centered, [0]) / (Nx.sum(mask) - 1)
 
-        covariances = Nx.put_slice(covariances, [k, 0, 0], Nx.new_axis(covariance, 0))
-        {covariances, {x, one_hot, means, k + 1}}
+        {eigenvalues, eigenvectors} = Nx.LinAlg.eigh(covariance, eps: @eigh_eps)
+
+        scalings = Nx.put_slice(scalings, [k, 0], Nx.new_axis(eigenvalues, 0))
+        rotations = Nx.put_slice(rotations, [k, 0, 0], Nx.new_axis(eigenvectors, 0))
+
+        {scalings, rotations, {x, one_hot, means, k + 1}}
       end
 
-    {scalings, rotations} = Nx.LinAlg.eigh(covariances, eps: @eigh_eps)
     scalings = (1 - reg_param) * scalings + reg_param
 
     %__MODULE__{

--- a/lib/scholar/discriminant_analysis/quadratic.ex
+++ b/lib/scholar/discriminant_analysis/quadratic.ex
@@ -149,13 +149,15 @@ defmodule Scholar.DiscriminantAnalysis.Quadratic do
     centered = x - Nx.take(means, y, axis: 0)
 
     # One covariance per class, decomposed as we go. Looping keeps the working
-    # set at O(num_samples * num_features); masking every class at once would
-    # need a {num_classes, num_samples, num_features} intermediate instead.
+    # set at O(num_samples * num_features), where masking every class at once
+    # would need a {num_classes, num_samples, num_features} intermediate, and it
+    # never holds the whole stack of covariances at once. Decomposing the stack
+    # in one batched call instead measures the same under EXLA, so there is
+    # nothing to win by holding it.
     #
-    # The decomposition also has to happen one class at a time. On Nx 0.9.x,
-    # `Nx.LinAlg.eigh/2` over a stack of matrices decomposes only the first one
-    # under EXLA and returns zeros for the rest. Fixed in Nx 0.13, but Scholar
-    # still supports 0.9.
+    # It also sidesteps `Nx.LinAlg.eigh/2` over a stack of matrices, which on
+    # Nx 0.9.x under EXLA decomposes only the first one and returns zeros for
+    # the rest. Fixed in Nx 0.13.
     scalings = Nx.broadcast(Nx.tensor(0, type: Nx.type(x)), {num_classes, num_features})
 
     rotations =

--- a/lib/scholar/discriminant_analysis/quadratic.ex
+++ b/lib/scholar/discriminant_analysis/quadratic.ex
@@ -144,30 +144,37 @@ defmodule Scholar.DiscriminantAnalysis.Quadratic do
     priors = class_count / num_samples
     means = Nx.dot(one_hot, [0], x, [0]) / Nx.new_axis(class_count, 1)
 
+    # Every sample centered by the mean of its own class, so the loop below only
+    # has to select rows rather than recentre them.
+    centered = x - Nx.take(means, y, axis: 0)
+
     # One covariance per class, decomposed as we go. Looping keeps the working
     # set at O(num_samples * num_features); masking every class at once would
     # need a {num_classes, num_samples, num_features} intermediate instead.
     #
-    # The decomposition also has to happen one class at a time: as of Nx 0.9.2,
-    # `Nx.LinAlg.eigh/2` on a stack of matrices only decomposes the first one
-    # under EXLA and returns zeros for the rest.
+    # The decomposition also has to happen one class at a time. On Nx 0.9.x,
+    # `Nx.LinAlg.eigh/2` over a stack of matrices decomposes only the first one
+    # under EXLA and returns zeros for the rest. Fixed in Nx 0.13, but Scholar
+    # still supports 0.9.
     scalings = Nx.broadcast(Nx.tensor(0, type: Nx.type(x)), {num_classes, num_features})
 
     rotations =
       Nx.broadcast(Nx.tensor(0, type: Nx.type(x)), {num_classes, num_features, num_features})
 
     {scalings, rotations, _} =
-      while {scalings, rotations, {x, one_hot, means, k = 0}}, k < num_classes do
-        mask = Nx.new_axis(one_hot[[.., k]], 1)
-        centered = (x - means[k]) * mask
-        covariance = Nx.dot(centered, [0], centered, [0]) / (Nx.sum(mask) - 1)
+      while {scalings, rotations, {centered, one_hot, class_count, k = Nx.u32(0)}},
+            k < num_classes do
+        # The mask is one or zero, so masking a single side of the product is
+        # enough to drop the rows belonging to the other classes.
+        in_class = Nx.new_axis(one_hot[[.., k]], 1)
+        covariance = Nx.dot(centered * in_class, [0], centered, [0]) / (class_count[k] - 1)
 
         {eigenvalues, eigenvectors} = Nx.LinAlg.eigh(covariance, eps: @eigh_eps)
 
         scalings = Nx.put_slice(scalings, [k, 0], Nx.new_axis(eigenvalues, 0))
         rotations = Nx.put_slice(rotations, [k, 0, 0], Nx.new_axis(eigenvectors, 0))
 
-        {scalings, rotations, {x, one_hot, means, k + 1}}
+        {scalings, rotations, {centered, one_hot, class_count, k + 1}}
       end
 
     scalings = (1 - reg_param) * scalings + reg_param
@@ -198,15 +205,17 @@ defmodule Scholar.DiscriminantAnalysis.Quadratic do
        ) do
     x = to_float(x)
 
-    # {num_classes, num_samples, num_features}
-    centered = Nx.new_axis(x, 0) - Nx.new_axis(means, 1)
-    rotated = Nx.dot(centered, [2], [0], rotations, [1], [0])
+    # Rotating `x - mean` is the same as rotating each separately, and doing it
+    # separately keeps one {num_samples, num_classes, num_features} tensor around
+    # instead of two.
+    rotated =
+      Nx.dot(x, [1], rotations, [1]) -
+        Nx.new_axis(Nx.dot(means, [1], [0], rotations, [1], [0]), 0)
 
-    mahalanobis = Nx.sum(rotated ** 2 / Nx.new_axis(scalings, 1), axes: [2])
+    mahalanobis = Nx.sum(rotated ** 2 / Nx.new_axis(scalings, 0), axes: [2])
     log_det = Nx.sum(Nx.log(scalings), axes: [1])
 
-    scores = -0.5 * (mahalanobis + Nx.new_axis(log_det, 1)) + Nx.new_axis(Nx.log(priors), 1)
-    Nx.transpose(scores)
+    -0.5 * (mahalanobis + Nx.new_axis(log_det, 0)) + Nx.new_axis(Nx.log(priors), 0)
   end
 
   @doc """

--- a/lib/scholar/discriminant_analysis/quadratic.ex
+++ b/lib/scholar/discriminant_analysis/quadratic.ex
@@ -1,0 +1,228 @@
+defmodule Scholar.DiscriminantAnalysis.Quadratic do
+  @moduledoc ~S"""
+  Quadratic Discriminant Analysis (QDA) for classification.
+
+  QDA fits a Gaussian density to each class, letting every class have its own
+  covariance matrix. Unlike `Scholar.DiscriminantAnalysis.Linear`, which pools a
+  single covariance across classes, the per-class covariances leave a quadratic
+  term in the score, so the decision boundary between two classes is a quadric
+  rather than a hyperplane. For a sample $x$ the score of class $k$ is
+
+  $$ \delta\_{k}(x) = -\frac{1}{2} \log |\Sigma\_{k}| - \frac{1}{2} (x - \mu\_{k})^{T} \Sigma\_{k}^{-1} (x - \mu\_{k}) + \log \pi\_{k} $$
+
+  where $\mu\_{k}$ is the class mean, $\Sigma\_{k}$ the class covariance and
+  $\pi\_{k}$ the class prior. The predicted class is the one with the highest
+  score.
+
+  Each covariance is stored through its eigendecomposition $\Sigma\_{k} = R\_{k}
+  \Lambda\_{k} R\_{k}^{T}$, which turns both the log-determinant and the
+  quadratic form into elementwise work over the eigenvalues.
+
+  Every class covariance is assumed to be invertible, which requires at least as
+  many samples as features in each class and no feature being a linear
+  combination of the others. Use `:reg_param` to shrink the eigenvalues towards
+  one when that does not hold.
+
+  Reference:
+
+  * [1] - [The Elements of Statistical Learning, Hastie, Tibshirani & Friedman, Section 4.3](https://hastie.su.domains/ElemStatLearn/)
+  """
+  import Nx.Defn
+  import Scholar.Shared
+
+  @derive {Nx.Container, containers: [:means, :priors, :scalings, :rotations]}
+  defstruct [:means, :priors, :scalings, :rotations]
+
+  # `Nx.LinAlg.eigh/2` defaults to `eps: 1.0e-4`, which leaves the eigenvalues
+  # about three digits short. QDA divides by them and takes their log, so the
+  # error is amplified rather than absorbed. Measured against LAPACK on the same
+  # f64 covariance, 1.0e-8 lands the eigenvalues within ~1.0e-7; tightening
+  # further makes it worse, since the iteration then runs into `:max_iter`.
+  @eigh_eps 1.0e-8
+
+  opts_schema = [
+    num_classes: [
+      type: :pos_integer,
+      required: true,
+      doc:
+        "Number of different classes used in training. Labels must be integers in `[0, num_classes)`."
+    ],
+    reg_param: [
+      type: {:or, [:float, :integer]},
+      default: 0.0,
+      doc: """
+      Regularizes the per-class covariance by shrinking its eigenvalues towards one,
+      as `(1 - reg_param) * eigenvalues + reg_param`. Use a value in `[0, 1]` when a
+      class has fewer samples than features, or when features are collinear, which
+      would otherwise leave the covariance singular.
+      """
+    ]
+  ]
+
+  @opts_schema NimbleOptions.new!(opts_schema)
+
+  @doc """
+  Fits a Quadratic Discriminant Analysis model for sample inputs `x` and target
+  labels `y`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  ## Return Values
+
+  The function returns a struct with the following parameters:
+
+    * `:means` - Class-wise mean of the samples, shape `{num_classes, num_features}`.
+
+    * `:priors` - Class prior probabilities, shape `{num_classes}`.
+
+    * `:scalings` - Eigenvalues of each class covariance, shape `{num_classes, num_features}`.
+
+    * `:rotations` - Eigenvectors of each class covariance, shape `{num_classes, num_features, num_features}`.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Quadratic.fit(x, y, num_classes: 2)
+      iex> Scholar.DiscriminantAnalysis.Quadratic.predict(model, Nx.tensor([[-1.5, -1.5], [1.5, 1.5]]))
+      #Nx.Tensor<
+        s32[2]
+        [0, 1]
+      >
+  """
+  deftransform fit(x, y, opts \\ []) do
+    if Nx.rank(x) != 2 do
+      raise ArgumentError,
+            "expected x to have shape {num_samples, num_features}, " <>
+              "got tensor with shape: #{inspect(Nx.shape(x))}"
+    end
+
+    if Nx.rank(y) != 1 do
+      raise ArgumentError,
+            "expected y to have shape {num_samples}, " <>
+              "got tensor with shape: #{inspect(Nx.shape(y))}"
+    end
+
+    if Nx.axis_size(x, 0) != Nx.axis_size(y, 0) do
+      raise ArgumentError,
+            "expected x and y to have the same number of samples, " <>
+              "got #{Nx.axis_size(x, 0)} and #{Nx.axis_size(y, 0)}"
+    end
+
+    opts = NimbleOptions.validate!(opts, @opts_schema)
+    fit_n(x, y, opts)
+  end
+
+  defnp fit_n(x, y, opts) do
+    x = to_float(x)
+    num_classes = opts[:num_classes]
+    reg_param = opts[:reg_param]
+    {num_samples, num_features} = Nx.shape(x)
+
+    one_hot =
+      (Nx.new_axis(y, 1) == Nx.new_axis(Nx.iota({num_classes}), 0)) |> Nx.as_type(Nx.type(x))
+
+    class_count = Nx.sum(one_hot, axes: [0])
+    priors = class_count / num_samples
+    means = Nx.dot(one_hot, [0], x, [0]) / Nx.new_axis(class_count, 1)
+
+    # One covariance per class. Looping keeps the working set at O(num_samples *
+    # num_features); masking every class at once would need a
+    # {num_classes, num_samples, num_features} intermediate instead.
+    covariances =
+      Nx.broadcast(Nx.tensor(0, type: Nx.type(x)), {num_classes, num_features, num_features})
+
+    {covariances, _} =
+      while {covariances, {x, one_hot, means, k = 0}}, k < num_classes do
+        mask = Nx.new_axis(one_hot[[.., k]], 1)
+        centered = (x - means[k]) * mask
+        covariance = Nx.dot(centered, [0], centered, [0]) / (Nx.sum(mask) - 1)
+
+        covariances = Nx.put_slice(covariances, [k, 0, 0], Nx.new_axis(covariance, 0))
+        {covariances, {x, one_hot, means, k + 1}}
+      end
+
+    {scalings, rotations} = Nx.LinAlg.eigh(covariances, eps: @eigh_eps)
+    scalings = (1 - reg_param) * scalings + reg_param
+
+    %__MODULE__{
+      means: means,
+      priors: priors,
+      scalings: scalings,
+      rotations: rotations
+    }
+  end
+
+  @doc """
+  Computes the quadratic discriminant scores of each class for samples `x`.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Quadratic.fit(x, y, num_classes: 2)
+      iex> scores = Scholar.DiscriminantAnalysis.Quadratic.decision_function(model, Nx.tensor([[1.5, 1.5]]))
+      iex> Nx.shape(scores)
+      {1, 2}
+  """
+  defn decision_function(
+         %__MODULE__{means: means, priors: priors, scalings: scalings, rotations: rotations},
+         x
+       ) do
+    x = to_float(x)
+
+    # {num_classes, num_samples, num_features}
+    centered = Nx.new_axis(x, 0) - Nx.new_axis(means, 1)
+    rotated = Nx.dot(centered, [2], [0], rotations, [1], [0])
+
+    mahalanobis = Nx.sum(rotated ** 2 / Nx.new_axis(scalings, 1), axes: [2])
+    log_det = Nx.sum(Nx.log(scalings), axes: [1])
+
+    scores = -0.5 * (mahalanobis + Nx.new_axis(log_det, 1)) + Nx.new_axis(Nx.log(priors), 1)
+    Nx.transpose(scores)
+  end
+
+  @doc """
+  Predicts the class of each sample in `x`.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Quadratic.fit(x, y, num_classes: 2)
+      iex> Scholar.DiscriminantAnalysis.Quadratic.predict(model, Nx.tensor([[-1.5, -1.5], [1.5, 1.5]]))
+      #Nx.Tensor<
+        s32[2]
+        [0, 1]
+      >
+  """
+  defn predict(%__MODULE__{} = model, x) do
+    scores = decision_function(model, x)
+    Nx.argmax(scores, axis: 1)
+  end
+
+  @doc """
+  Estimates class probabilities for samples `x` by applying a softmax to the
+  discriminant scores.
+
+  ## Examples
+
+      iex> x = Nx.tensor([[-2.0, -1.0], [-1.0, -1.0], [-1.0, -2.0], [1.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+      iex> y = Nx.tensor([0, 0, 0, 1, 1, 1])
+      iex> model = Scholar.DiscriminantAnalysis.Quadratic.fit(x, y, num_classes: 2)
+      iex> probs = Scholar.DiscriminantAnalysis.Quadratic.predict_probability(model, Nx.tensor([[1.5, 1.5]]))
+      iex> Nx.sum(probs) |> Nx.round()
+      #Nx.Tensor<
+        f32
+        1.0
+      >
+  """
+  defn predict_probability(%__MODULE__{} = model, x) do
+    scores = decision_function(model, x)
+    scores = scores - stop_grad(Nx.reduce_max(scores, axes: [1], keep_axes: true))
+    exp = Nx.exp(scores)
+    exp / Nx.sum(exp, axes: [1], keep_axes: true)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -76,6 +76,7 @@ defmodule Scholar.MixProject do
           Scholar.Decomposition.KernelPCA,
           Scholar.Decomposition.PCA,
           Scholar.DiscriminantAnalysis.Linear,
+          Scholar.DiscriminantAnalysis.Quadratic,
           Scholar.Integrate,
           Scholar.Interpolation.BezierSpline,
           Scholar.Interpolation.CubicSpline,

--- a/test/scholar/discriminant_analysis/quadratic_test.exs
+++ b/test/scholar/discriminant_analysis/quadratic_test.exs
@@ -131,6 +131,36 @@ defmodule Scholar.DiscriminantAnalysis.QuadraticTest do
       )
     end
 
+    test ":reg_param makes a class with fewer samples than features usable" do
+      # Class 1 has 3 samples in 4 dimensions, so its covariance is singular and
+      # its smallest eigenvalues are zero. Dividing the score by those is what
+      # `:reg_param` is there to avoid.
+      x =
+        Nx.tensor([
+          [0.0, 0.0, 0.0, 0.0],
+          [1.0, 0.0, 0.5, 0.25],
+          [0.0, 1.0, 0.25, 0.5],
+          [0.5, 0.5, 1.0, 0.0],
+          [0.25, 0.75, 0.0, 1.0],
+          [5.0, 5.0, 5.0, 5.0],
+          [5.5, 4.5, 5.25, 4.75],
+          [4.5, 5.5, 4.75, 5.25]
+        ])
+
+      y = Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1])
+
+      unregularized = Quadratic.fit(x, y, num_classes: 2)
+      assert Nx.to_number(Nx.reduce_min(unregularized.scalings)) == 0.0
+
+      model = Quadratic.fit(x, y, num_classes: 2, reg_param: 0.5)
+      assert Nx.to_number(Nx.reduce_min(model.scalings)) >= 0.5
+
+      scores = Quadratic.decision_function(model, x)
+      assert Nx.to_number(Nx.any(Nx.is_infinity(scores))) == 0
+      assert Nx.to_number(Nx.any(Nx.is_nan(scores))) == 0
+      assert Quadratic.predict(model, x) == y
+    end
+
     test "accepts integer input" do
       x_int = Nx.tensor([[-2, -1], [-1, -1], [-1, -2], [-2, -2], [1, 1], [1, 2], [2, 1], [2, 2]])
 

--- a/test/scholar/discriminant_analysis/quadratic_test.exs
+++ b/test/scholar/discriminant_analysis/quadratic_test.exs
@@ -1,0 +1,332 @@
+defmodule Scholar.DiscriminantAnalysis.QuadraticTest do
+  use Scholar.Case, async: true
+  alias Scholar.DiscriminantAnalysis.Quadratic
+  doctest Quadratic
+
+  # Reference values come from scikit-learn 1.6.1
+  # (`QuadraticDiscriminantAnalysis`), using `_decision_function` for the raw
+  # class scores, since `decision_function` collapses to a single column when
+  # there are two classes.
+
+  defp two_class_x do
+    Nx.tensor([
+      [-2.0, -1.0],
+      [-1.0, -1.0],
+      [-1.0, -2.0],
+      [-2.0, -2.0],
+      [1.0, 1.0],
+      [1.0, 2.0],
+      [2.0, 1.0],
+      [2.0, 2.0]
+    ])
+  end
+
+  defp two_class_y, do: Nx.tensor([0, 0, 0, 0, 1, 1, 1, 1])
+
+  defp three_class_x do
+    Nx.tensor([
+      [0.0, 0.0],
+      [0.5, 0.25],
+      [0.25, 0.5],
+      [-0.5, -0.25],
+      [-0.25, -0.5],
+      [4.0, 4.0],
+      [4.5, 3.5],
+      [3.5, 4.5],
+      [4.25, 4.25],
+      [3.75, 3.75],
+      [-4.0, 4.0],
+      [-3.5, 4.5],
+      [-4.5, 3.5],
+      [-4.25, 4.25],
+      [-3.75, 3.75]
+    ])
+  end
+
+  defp three_class_y, do: Nx.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2])
+
+  defp three_class_t, do: Nx.tensor([[0.1, 0.1], [4.0, 4.0], [-4.0, 4.0], [0.0, 4.0]])
+
+  # Both classes share a mean and differ only in spread, so a shared covariance
+  # cannot tell them apart. This is the case QDA exists for.
+  defp nested_x do
+    Nx.tensor([
+      [0.0, 0.0],
+      [0.25, 0.0],
+      [-0.25, 0.0],
+      [0.0, 0.25],
+      [0.0, -0.25],
+      [0.125, 0.125],
+      [-0.125, -0.125],
+      [3.0, 0.0],
+      [-3.0, 0.0],
+      [0.0, 3.0],
+      [0.0, -3.0],
+      [2.0, 2.0],
+      [-2.0, -2.0],
+      [2.0, -2.0],
+      [-2.0, 2.0]
+    ])
+  end
+
+  defp nested_y, do: Nx.tensor([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1])
+
+  describe "fit" do
+    test "means, priors and scalings match sklearn on two classes" do
+      model = Quadratic.fit(two_class_x(), two_class_y(), num_classes: 2)
+
+      assert_all_close(model.means, Nx.tensor([[-1.5, -1.5], [1.5, 1.5]]))
+      assert_all_close(model.priors, Nx.tensor([0.5, 0.5]))
+
+      # `eigh` pairs every eigenvalue with its eigenvector, but the order along
+      # the axis is not part of its contract and QDA sums over all of them, so
+      # the reference values are compared as a sorted set.
+      assert_all_close(
+        Nx.sort(model.scalings, axis: 1),
+        Nx.tensor([[0.3333333, 0.3333333], [0.3333333, 0.3333333]])
+      )
+    end
+
+    test "means, priors and scalings match sklearn on three classes" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert_all_close(model.means, Nx.tensor([[0.0, 0.0], [4.0, 4.0], [-4.0, 4.0]]))
+      assert_all_close(model.priors, Nx.tensor([0.3333333, 0.3333333, 0.3333333]))
+
+      assert_all_close(
+        Nx.sort(model.scalings, axis: 1),
+        Nx.tensor([[0.03125, 0.28125], [0.0625, 0.25], [0.0625, 0.25]])
+      )
+    end
+
+    test "rotations have the shape of a per-class basis" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert Nx.shape(model.rotations) == {3, 2, 2}
+      assert Nx.shape(model.scalings) == {3, 2}
+      assert Nx.shape(model.means) == {3, 2}
+    end
+
+    test "the rotations reconstruct each class covariance" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      scaled = Nx.multiply(model.rotations, Nx.new_axis(model.scalings, 1))
+
+      rebuilt =
+        Nx.dot(scaled, [2], [0], Nx.transpose(model.rotations, axes: [0, 2, 1]), [1], [0])
+
+      # Covariance of class 1, computed directly.
+      centered = Nx.tensor([[0.0, 0.0], [0.5, -0.5], [-0.5, 0.5], [0.25, 0.25], [-0.25, -0.25]])
+      covariance = Nx.dot(centered, [0], centered, [0]) |> Nx.divide(4)
+
+      assert_all_close(rebuilt[1], covariance)
+    end
+
+    test ":reg_param shrinks the scalings towards one, matching sklearn" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3, reg_param: 0.4)
+
+      assert_all_close(
+        Nx.sort(model.scalings, axis: 1),
+        Nx.tensor([[0.41875, 0.56875], [0.4375, 0.55], [0.4375, 0.55]])
+      )
+    end
+
+    test "accepts integer input" do
+      x_int = Nx.tensor([[-2, -1], [-1, -1], [-1, -2], [-2, -2], [1, 1], [1, 2], [2, 1], [2, 2]])
+
+      from_int = Quadratic.fit(x_int, two_class_y(), num_classes: 2)
+      from_float = Quadratic.fit(two_class_x(), two_class_y(), num_classes: 2)
+
+      assert_all_close(from_int.means, from_float.means)
+      assert_all_close(from_int.scalings, from_float.scalings)
+    end
+
+    test "propagates f64 input" do
+      model =
+        Quadratic.fit(Nx.as_type(two_class_x(), :f64), two_class_y(), num_classes: 2)
+
+      assert Nx.type(model.means) == {:f, 64}
+      assert Nx.type(model.scalings) == {:f, 64}
+    end
+  end
+
+  describe "decision_function" do
+    test "matches sklearn on three classes" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert_all_close(
+        Quadratic.decision_function(model, three_class_t()),
+        Nx.tensor([
+          [1.232956, -242.379171, -255.059171],
+          [-55.620378, 0.980829, -319.019171],
+          [-510.731489, -319.019171, 0.980829],
+          [-140.953711, -79.019171, -79.019171]
+        ]),
+        rtol: 1.0e-3
+      )
+    end
+
+    test "matches sklearn with :reg_param" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3, reg_param: 0.4)
+
+      assert_all_close(
+        Quadratic.decision_function(model, three_class_t()),
+        Nx.tensor([
+          [-0.398797, -35.152069, -36.975965],
+          [-28.513083, -0.386355, -66.048692],
+          [-38.59017, -66.048692, -0.386355],
+          [-16.96642, -16.801939, -16.801939]
+        ]),
+        rtol: 1.0e-3
+      )
+    end
+
+    test "predict is the argmax of the decision function" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+      scores = Quadratic.decision_function(model, three_class_t())
+
+      assert Quadratic.predict(model, three_class_t()) == Nx.argmax(scores, axis: 1)
+    end
+  end
+
+  describe "predict" do
+    test "matches sklearn on two classes" do
+      model = Quadratic.fit(two_class_x(), two_class_y(), num_classes: 2)
+      t = Nx.tensor([[-1.5, -1.5], [1.5, 1.5], [0.0, 0.0]])
+
+      assert Quadratic.predict(model, t) == Nx.tensor([0, 1, 0])
+    end
+
+    test "matches sklearn on three classes" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert Quadratic.predict(model, three_class_t()) == Nx.tensor([0, 1, 2, 1])
+    end
+
+    test "separates classes that share a mean but differ in covariance" do
+      # The point of QDA: LDA pools one covariance and scores both classes
+      # identically here, so it cannot beat the majority class.
+      model = Quadratic.fit(nested_x(), nested_y(), num_classes: 2)
+
+      assert Quadratic.predict(model, nested_x()) == nested_y()
+
+      linear =
+        Scholar.DiscriminantAnalysis.Linear.fit(nested_x(), nested_y(), num_classes: 2)
+
+      linear_correct =
+        Scholar.DiscriminantAnalysis.Linear.predict(linear, nested_x())
+        |> Nx.equal(nested_y())
+        |> Nx.sum()
+        |> Nx.to_number()
+
+      assert linear_correct < Nx.axis_size(nested_x(), 0)
+    end
+
+    test "recovers the training labels on well-separated classes" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert Quadratic.predict(model, three_class_x()) == three_class_y()
+    end
+  end
+
+  describe "predict_probability" do
+    test "matches sklearn on three classes" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert_all_close(
+        Quadratic.predict_probability(model, three_class_t()),
+        Nx.tensor([
+          [1.0, 0.0, 0.0],
+          [0.0, 1.0, 0.0],
+          [0.0, 0.0, 1.0],
+          [0.0, 0.5, 0.5]
+        ])
+      )
+    end
+
+    test "matches sklearn where the classes overlap" do
+      model = Quadratic.fit(nested_x(), nested_y(), num_classes: 2)
+
+      assert_all_close(
+        Quadratic.predict_probability(model, Nx.tensor([[0.0, 0.0], [0.1, -0.1]])),
+        Nx.tensor([[0.9940322, 0.0059678], [0.9904105, 0.0095895]])
+      )
+    end
+
+    test "rows sum to one" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+      probs = Quadratic.predict_probability(model, three_class_t())
+
+      assert_all_close(Nx.sum(probs, axes: [1]), Nx.broadcast(1.0, {4}))
+    end
+  end
+
+  describe "jit" do
+    # Required by AGENTS.md: the whole model has to survive being compiled.
+    test "fit and predict run under jit_apply" do
+      x = three_class_x()
+      y = three_class_y()
+      t = three_class_t()
+
+      labels =
+        Nx.Defn.jit_apply(
+          fn x, y, t ->
+            model = Quadratic.fit(x, y, num_classes: 3)
+            Quadratic.predict(model, t)
+          end,
+          [x, y, t]
+        )
+
+      assert labels == Nx.tensor([0, 1, 2, 1])
+    end
+
+    test "decision_function runs under jit_apply" do
+      model = Quadratic.fit(three_class_x(), three_class_y(), num_classes: 3)
+
+      assert Nx.Defn.jit_apply(&Quadratic.decision_function/2, [model, three_class_t()]) ==
+               Quadratic.decision_function(model, three_class_t())
+    end
+  end
+
+  describe "errors" do
+    test "when x is not a matrix" do
+      assert_raise ArgumentError,
+                   "expected x to have shape {num_samples, num_features}, got tensor with shape: {3}",
+                   fn ->
+                     Quadratic.fit(Nx.tensor([1, 2, 3]), Nx.tensor([0, 1, 0]), num_classes: 2)
+                   end
+    end
+
+    test "when y is not a vector" do
+      assert_raise ArgumentError,
+                   "expected y to have shape {num_samples}, got tensor with shape: {2, 1}",
+                   fn ->
+                     Quadratic.fit(Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), Nx.tensor([[0], [1]]),
+                       num_classes: 2
+                     )
+                   end
+    end
+
+    test "when x and y disagree on the number of samples" do
+      assert_raise ArgumentError,
+                   "expected x and y to have the same number of samples, got 2 and 3",
+                   fn ->
+                     Quadratic.fit(Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), Nx.tensor([0, 1, 0]),
+                       num_classes: 2
+                     )
+                   end
+    end
+
+    test "when :num_classes is missing" do
+      assert_raise NimbleOptions.ValidationError,
+                   "required :num_classes option not found, received options: []",
+                   fn -> Quadratic.fit(two_class_x(), two_class_y()) end
+    end
+
+    test "when :num_classes is not a positive integer" do
+      assert_raise NimbleOptions.ValidationError,
+                   "invalid value for :num_classes option: expected positive integer, got: 2.0",
+                   fn -> Quadratic.fit(two_class_x(), two_class_y(), num_classes: 2.0) end
+    end
+  end
+end


### PR DESCRIPTION
Closes #338. LDA landed in #341, so this completes it.

Adds `Scholar.DiscriminantAnalysis.Quadratic`. Each class keeps its own covariance, stored as its eigendecomposition so both the log determinant and the quadratic form become elementwise work over the eigenvalues. Options are `:num_classes` (required, as in LDA) and `:reg_param`.

### Two implementation notes

Covariances are built and decomposed one class at a time. That keeps the working set at O(num_samples * num_features), and it avoids `Nx.LinAlg.eigh/2` over a stack of matrices, which on Nx 0.9.x under EXLA decomposes only the first one and returns zeros for the rest. Fixed in Nx 0.13, but Scholar still allows `~> 0.9`.

`eigh` is called with a tighter `eps` than its default. QDA divides by the eigenvalues and takes their log, and the default `1.0e-4` leaves them about three digits short in the pure Nx implementation. Compiled backends replace that routine and are unaffected.

### Validation against scikit-learn 1.6.1

Twelve scenarios (2 to 5 classes, up to 10 features, unbalanced, overlapping, correlated features, mixed scales, `reg_param`, singular covariance), EXLA in f64: means, eigenvalues and scores within 6.0e-8, identical predictions in eleven of twelve.

On a 30% stratified holdout, every prediction agrees:

| dataset | this PR | scikit-learn | LDA |
|---|---|---|---|
| iris | 1.0000 | 1.0000 | 1.0000 |
| wine | 0.9815 | 0.9815 | 1.0000 |
| breast_cancer | 0.9532 | 0.9532 | 0.9532 |
| digits (61 features, 10 classes) | 0.9704 | 0.9704 | 0.9593 |

### One deliberate divergence

The twelfth scenario is a class with fewer samples than features. scikit-learn keeps only `min(class_size, num_features)` components and works in the subspace the class spans; this keeps all directions and relies on `:reg_param`. Noted in the moduledoc.

Tests include the `jit_apply` case AGENTS.md asks for, and two classes that share a mean and differ only in spread, where LDA cannot separate them.