### PR TITLE
Fix BayesianRidgeRegression never converging (state rotation bug in the iteration loop)

### DIFF
--- a/lib/scholar/linear/bayesian_ridge_regression.ex
+++ b/lib/scholar/linear/bayesian_ridge_regression.ex
@@ -214,12 +214,12 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
       iex> model.coefficients
       #Nx.Tensor<
         f32[1]
-        [0.9932512044906616]
+        [0.9999999403953552]
       >
       iex> model.intercept
       #Nx.Tensor<
         f32
-        0.03644371032714844
+        4.76837158203125e-7
       >
   """
   deftransform fit(x, y, opts \\ []) do
@@ -241,7 +241,7 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
     # handle vector types
     # handle default alpha value, add eps to avoid division by 0
     eps = Nx.Constants.smallest_positive_normal(x_type)
-    default_alpha = Nx.divide(1, Nx.add(Nx.variance(x), eps))
+    default_alpha = Nx.divide(1, Nx.add(Nx.variance(y), eps))
     alpha = Keyword.get(opts, :alpha_init, default_alpha)
     alpha = Nx.tensor(alpha, type: x_type)
 
@@ -313,11 +313,11 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
     {n_samples, n_features} = Nx.shape(x)
     {coef, rmse} = update_coef(x, y, n_samples, n_features, xt_y, u, vh, eigenvals, alpha, lambda)
 
-    {{coef, alpha, lambda, _rmse, iter, has_converged, scores}, _} =
+    {{coef, _rmse, alpha, lambda, iter, has_converged, scores}, _} =
       while {{coef, rmse, alpha, lambda, iter = Nx.u64(0), has_converged = Nx.u8(0),
               scores = scores},
              {x, y, xt_y, u, s, vh, eigenvals, alpha_1, alpha_2, lambda_1, lambda_2, iterations}},
-            iter <= iterations and not has_converged do
+            iter < iterations and not has_converged do
         scores =
           if opts[:compute_scores?] do
             new_score =
@@ -349,7 +349,7 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
 
         has_converged = Nx.sum(Nx.abs(coef - coef_new)) < 1.0e-8
 
-        {{coef_new, alpha, lambda, rmse, iter + 1, has_converged, scores},
+        {{coef_new, rmse, alpha, lambda, iter + 1, has_converged, scores},
          {x, y, xt_y, u, s, vh, eigenvals, alpha_1, alpha_2, lambda_1, lambda_2, iterations}}
       end
 
@@ -437,8 +437,8 @@ defmodule Scholar.Linear.BayesianRidgeRegression do
       iex> model = Scholar.Linear.BayesianRidgeRegression.fit(x, y)
       iex> Scholar.Linear.BayesianRidgeRegression.predict(model, Nx.tensor([[1], [3], [4]]))
       Nx.tensor(
-        [1.02969491481781, 3.0161972045898438, 4.009448528289795]  
-      )  
+        [1.0000004768371582, 3.000000238418579, 4.0]
+      )
   """
   deftransform predict(%__MODULE__{coefficients: coeff, intercept: intercept} = _model, x) do
     predict_n(coeff, intercept, x)

--- a/test/scholar/linear/bayesian_ridge_regression_test.exs
+++ b/test/scholar/linear/bayesian_ridge_regression_test.exs
@@ -70,7 +70,7 @@ defmodule Scholar.Linear.BayesianRidgeRegressionTest do
   test "compute scores" do
     {x, y} = diabetes_data()
     eps = Nx.Constants.smallest_positive_normal(:f64)
-    alpha = Nx.divide(1, Nx.add(Nx.variance(x), eps))
+    alpha = Nx.divide(1, Nx.add(Nx.variance(y), eps))
     lambda = 1.0
     alpha_1 = 0.1
     alpha_2 = 0.1
@@ -92,6 +92,55 @@ defmodule Scholar.Linear.BayesianRidgeRegressionTest do
 
     first_score = brr.scores[0]
     assert_all_close(score, first_score, rtol: 0.05)
+  end
+
+  test "alpha and lambda converge without oscillating across iteration counts" do
+    {x, y} = diabetes_data()
+    y = Nx.flatten(y)
+
+    # Reference alpha_ values from sklearn 1.6.1 BayesianRidge on the same data
+    # (default alpha_init/lambda_init, default hyperparameters).
+    reference_alpha = %{
+      1 => 2.51380100e-4,
+      5 => 3.37994664e-4,
+      50 => 3.51229877e-4,
+      51 => 3.51229877e-4,
+      299 => 3.51229877e-4,
+      300 => 3.51229877e-4
+    }
+
+    for {iterations, expected_alpha} <- reference_alpha do
+      model = BayesianRidgeRegression.fit(x, y, iterations: iterations)
+      assert_all_close(model.alpha, expected_alpha, rtol: 5.0e-3)
+    end
+  end
+
+  test "alpha and lambda are stable between adjacent iteration counts" do
+    {x, y} = diabetes_data()
+    y = Nx.flatten(y)
+
+    for {low_iters, high_iters} <- [{50, 51}, {100, 101}, {299, 300}] do
+      low = BayesianRidgeRegression.fit(x, y, iterations: low_iters)
+      high = BayesianRidgeRegression.fit(x, y, iterations: high_iters)
+
+      assert_all_close(low.alpha, high.alpha, rtol: 1.0e-3)
+      assert_all_close(low.lambda, high.lambda, rtol: 1.0e-3)
+      assert_all_close(low.coefficients, high.coefficients, atol: 1.0e-4)
+    end
+  end
+
+  test "default alpha_init matches the documented 1/Var(y)" do
+    {x, y} = diabetes_data()
+    y = Nx.flatten(y)
+
+    eps = Nx.Constants.smallest_positive_normal(:f32)
+    alpha_init = Nx.to_number(Nx.divide(1, Nx.add(Nx.variance(y), eps)))
+
+    default_model = BayesianRidgeRegression.fit(x, y, iterations: 1)
+    explicit_model = BayesianRidgeRegression.fit(x, y, iterations: 1, alpha_init: alpha_init)
+
+    assert_all_close(default_model.alpha, explicit_model.alpha, atol: 1.0e-10)
+    assert_all_close(default_model.coefficients, explicit_model.coefficients, atol: 1.0e-6)
   end
 
   defnp compute_score(x, y, alpha, lambda, alpha_1, alpha_2, lambda_1, lambda_2) do


### PR DESCRIPTION
## Bug

`BayesianRidgeRegression.fit/3` never converges on real data. `alpha` and
`lambda` oscillate in a 2-cycle depending on the parity of `:iterations`
instead of converging to the values scikit-learn's `BayesianRidge` finds on
the same data.

Reproduced on the diabetes dataset already used by this test file
(`test/support/diabetes_data_raw.csv`), comparing against scikit-learn 1.6.1:

| iterations | alpha (before) | alpha (after) | sklearn |
|---:|---:|---:|---:|
| 1   | 2.51e-4 | 2.51e-4 | 2.51e-4 |
| 50  | 3.25e-4 | 3.51e-4 | 3.51e-4 |
| 51  | 1.53e+5 | 3.51e-4 | 3.51e-4 |
| 299 | 8.70e+4 | 3.51e-4 | 3.51e-4 |
| 300 | 5.75e-4 | 3.51e-4 | 3.51e-4 |

Adjacent iteration counts can disagree by orders of magnitude (299 vs 300
above), and this holds all the way out to the max iteration count, it never
settles.

Root cause: inside the `while` loop in `fit_n`, the accumulator is declared
as `{coef, rmse, alpha, lambda, ...}` but the loop body returns
`{coef_new, alpha, lambda, rmse, ...}`. Since Nx.Defn's `while` rebinds
loop-carried values by position, not by name, this silently rotates
`rmse`/`alpha`/`lambda` through the wrong slots on every iteration after the
first. `rmse` (order of magnitude ~1e5 on this dataset) ends up used in
place of `lambda` in the `gamma` update, which is what produces the
oscillation.

Two smaller, related bugs are fixed alongside it:
- `default_alpha` used `Var(x)` (pooled variance of the whole design matrix)
  instead of the documented `Var(y)`.
- The loop condition (`iter <= iterations`) ran one extra iteration beyond
  what `:iterations` requests.

Neither of these two causes the oscillation on its own, verified in
isolation; the tuple ordering is the actual cause.

## Fix

Reorder the loop body's return tuple (and the destructuring pattern that
reads the loop's final state) to match the declared accumulator order.
Fix `default_alpha` to use `Var(y)`. Fix the off-by-one in the loop bound.

## Testing

Verified against scikit-learn 1.6.1 `BayesianRidge` on the diabetes dataset.
Added three tests: convergence matches the sklearn reference across a range
of iteration counts, adjacent iteration counts no longer disagree, and the
default `alpha_init` matches the documented `1/Var(y)`.

The two moduledoc doctests changed: the old expected values were the result
of the bug. For the toy `y = x` dataset in the doctest, the model now
converges to the mathematically exact answer (coefficient 1.0, predictions
matching y exactly) instead of a slightly-off fit.