### PR TITLE
Support precomputed dissimilarities in hierarchical clustering

### DIFF
--- a/lib/scholar/cluster/hierarchical.ex
+++ b/lib/scholar/cluster/hierarchical.ex
@@ -12,7 +12,7 @@ defmodule Scholar.Cluster.Hierarchical do
 
   Due to the requirements of the current implementation, only these options are supported:
 
-    * `dissimilarity: :euclidean`
+    * `dissimilarity: :euclidean | :precomputed`
     * `linkage: :average | :complete | :single | :ward | :weighted`
 
   Our current algorithm is $O(\\frac{n^2}{p} \\cdot \\log(n))$ where $n$ is the number of data points
@@ -33,8 +33,8 @@ defmodule Scholar.Cluster.Hierarchical do
   defstruct [:clades, :dissimilarities, :num_points, :sizes]
 
   @dissimilarity_types [
-    :euclidean
-    # :precomputed
+    :euclidean,
+    :precomputed
   ]
 
   @linkage_types [
@@ -59,6 +59,17 @@ defmodule Scholar.Cluster.Hierarchical do
       Choices:
 
         * `:euclidean` - L2 norm.
+
+        * `:precomputed` - `data` is already a pairwise dissimilarity matrix of shape
+          `{num_obs, num_obs}` and is used as is. It must be symmetric. Its diagonal is
+          ignored, so it may hold any value. This is useful when the dissimilarity is
+          expensive to recompute, comes from outside Scholar, or is not derived from
+          coordinates at all, such as the mutual reachability used by density based
+          clustering.
+
+          Symmetry is not checked, since that would require inspecting the tensor.
+          Note also that `linkage: :ward` assumes euclidean dissimilarities, so pairing
+          it with an arbitrary precomputed matrix is not meaningful.
 
       See "Limitations" in the moduledoc for an explanation of the lack of choices.
       """
@@ -134,6 +145,18 @@ defmodule Scholar.Cluster.Hierarchical do
         num_points: 5,
         sizes: Nx.tensor([2, 2, 3, 5])
       }
+
+  Passing the pairwise dissimilarities directly gives the same model:
+
+      iex> data = Nx.tensor([[2], [7], [9], [0], [3]])
+      iex> dissimilarities = Scholar.Metrics.Distance.pairwise_euclidean(data)
+      iex> Hierarchical.fit(dissimilarities, dissimilarity: :precomputed)
+      %Scholar.Cluster.Hierarchical{
+        clades: Nx.tensor([[0, 4], [1, 2], [3, 5], [6, 7]]),
+        dissimilarities: Nx.tensor([1.0, 2.0, 2.0, 4.0]),
+        num_points: 5,
+        sizes: Nx.tensor([2, 2, 3, 5])
+      }
   """
   deftransform fit(%Nx.Tensor{} = data, opts \\ []) do
     opts = NimbleOptions.validate!(opts, @fit_opts_schema)
@@ -142,7 +165,7 @@ defmodule Scholar.Cluster.Hierarchical do
 
     dissimilarity_fun =
       case dissimilarity do
-        # :precomputed -> &Function.identity/1
+        :precomputed -> &Function.identity/1
         :euclidean -> &Scholar.Metrics.Distance.pairwise_euclidean/1
       end
 
@@ -165,11 +188,18 @@ defmodule Scholar.Cluster.Hierarchical do
       end
 
     n =
-      case Nx.shape(data) do
-        {n, _num_features} ->
+      case {dissimilarity, Nx.shape(data)} do
+        {:precomputed, {n, n}} ->
           n
 
-        other ->
+        {:precomputed, other} ->
+          raise ArgumentError,
+                "Expected a square rank 2 (`{num_obs, num_obs}`) tensor when `dissimilarity: :precomputed`, found shape: #{inspect(other)}."
+
+        {_, {n, _num_features}} ->
+          n
+
+        {_, other} ->
           raise ArgumentError,
                 "Expected a rank 2 (`{num_obs, num_features}`) tensor, found shape: #{inspect(other)}."
       end

--- a/test/scholar/cluster/hierarchical_test.exs
+++ b/test/scholar/cluster/hierarchical_test.exs
@@ -199,7 +199,108 @@ defmodule Scholar.Cluster.HierarchicalTest do
     end
   end
 
+  describe "precomputed dissimilarity" do
+    setup do
+      %{
+        data: Nx.tensor([[1, 5], [2, 5], [1, 4], [4, 5], [5, 5], [5, 4], [1, 2], [1, 1], [2, 1]]),
+        # A dissimilarity that does not come from coordinates and violates the triangle
+        # inequality, since d(0, 2) = 9 is greater than d(0, 1) + d(1, 2) = 2. It cannot be
+        # produced by a euclidean fit. Reference values from
+        # `scipy.cluster.hierarchy.linkage(squareform(d), method=...)`.
+        dissimilarities:
+          Nx.tensor([
+            [0.0, 1.0, 9.0, 8.0, 7.0],
+            [1.0, 0.0, 1.0, 8.0, 7.0],
+            [9.0, 1.0, 0.0, 8.0, 7.0],
+            [8.0, 8.0, 8.0, 0.0, 2.0],
+            [7.0, 7.0, 7.0, 2.0, 0.0]
+          ])
+      }
+    end
+
+    for linkage <- [:average, :complete, :single, :ward, :weighted] do
+      test "#{linkage} matches computing the dissimilarities internally", %{data: data} do
+        linkage = unquote(linkage)
+        dissimilarities = Scholar.Metrics.Distance.pairwise_euclidean(data)
+
+        assert Hierarchical.fit(dissimilarities, dissimilarity: :precomputed, linkage: linkage) ==
+                 Hierarchical.fit(data, dissimilarity: :euclidean, linkage: linkage)
+      end
+    end
+
+    test "single matches scipy", %{dissimilarities: d} do
+      model = Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :single)
+
+      assert model.dissimilarities == Nx.tensor([1.0, 1.0, 2.0, 7.0])
+      assert model.sizes == Nx.tensor([2, 3, 2, 5])
+      assert model.num_points == 5
+    end
+
+    test "complete matches scipy", %{dissimilarities: d} do
+      model = Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :complete)
+
+      assert model.dissimilarities == Nx.tensor([1.0, 2.0, 8.0, 9.0])
+    end
+
+    test "average matches scipy", %{dissimilarities: d} do
+      model = Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :average)
+
+      assert model.dissimilarities == Nx.tensor([1.0, 2.0, 5.0, 7.5])
+    end
+
+    test "weighted matches scipy", %{dissimilarities: d} do
+      model = Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :weighted)
+
+      assert model.dissimilarities == Nx.tensor([1.0, 2.0, 5.0, 7.5])
+    end
+
+    test "the diagonal is ignored", %{dissimilarities: d} do
+      polluted = Nx.put_diagonal(d, Nx.tensor([100.0, 100.0, 100.0, 100.0, 100.0]))
+
+      assert Hierarchical.fit(polluted, dissimilarity: :precomputed) ==
+               Hierarchical.fit(d, dissimilarity: :precomputed)
+    end
+
+    test "labels can be derived from a precomputed model", %{dissimilarities: d} do
+      model = Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :single)
+
+      assert Hierarchical.labels_list(model, cluster_by: [num_clusters: 2]) == [0, 0, 0, 1, 1]
+    end
+
+    test "works with jit_apply", %{data: data} do
+      dissimilarities = Scholar.Metrics.Distance.pairwise_euclidean(data)
+
+      jitted =
+        Nx.Defn.jit_apply(
+          fn d -> Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :single) end,
+          [dissimilarities]
+        )
+
+      assert jitted == Hierarchical.fit(dissimilarities, dissimilarity: :precomputed)
+    end
+  end
+
   describe "errors" do
+    test "need a square tensor when dissimilarity is precomputed" do
+      assert_raise(
+        ArgumentError,
+        "Expected a square rank 2 (`{num_obs, num_obs}`) tensor when `dissimilarity: :precomputed`, found shape: {3, 2}.",
+        fn ->
+          Hierarchical.fit(Nx.tensor([[1, 2], [3, 4], [5, 6]]), dissimilarity: :precomputed)
+        end
+      )
+    end
+
+    test "need a rank 2 tensor when dissimilarity is precomputed" do
+      assert_raise(
+        ArgumentError,
+        "Expected a square rank 2 (`{num_obs, num_obs}`) tensor when `dissimilarity: :precomputed`, found shape: {3}.",
+        fn ->
+          Hierarchical.fit(Nx.tensor([1, 2, 3]), dissimilarity: :precomputed)
+        end
+      )
+    end
+
     test "need a rank 2 tensor" do
       assert_raise(
         ArgumentError,


### PR DESCRIPTION
`dissimilarity: :precomputed` was already sketched out in `Scholar.Cluster.Hierarchical`
but left commented out since the module was added in #187. This enables it.

With it, `fit/2` accepts a `{num_obs, num_obs}` dissimilarity matrix directly instead of
computing one from coordinates. That covers dissimilarities that are expensive to
recompute, come from outside Scholar, or are not derived from coordinates at all.

My motivation is HDBSCAN, which clusters a mutual reachability matrix rather than the
raw points. I plan to send that as a follow up and would rather reuse the existing
single linkage implementation than duplicate it.

## Validation

The check is that a precomputed fit on the pairwise euclidean matrix produces
a model identical to a euclidean fit on the raw data, asserted for all five linkages.

Beyond that, a dissimilarity matrix that cannot come from coordinates (it violates the
triangle inequality) is checked against `scipy.cluster.hierarchy.linkage` for single,
complete, average and weighted.

Also covered: the diagonal is ignored, labels can be derived from a precomputed model,
`jit_apply` works, and a non square input raises.

Symmetry is not validated, since checking it would mean inspecting the tensor inside
`deftransform`. It is documented as a caller requirement, along with a note that
`:ward` assumes euclidean dissimilarities.