### PR TITLE
Replace Hierarchical's round-based merge with nearest-neighbor chain

### DIFF
--- a/lib/scholar/cluster/hierarchical.ex
+++ b/lib/scholar/cluster/hierarchical.ex
@@ -15,11 +15,10 @@ defmodule Scholar.Cluster.Hierarchical do
     * `dissimilarity: :euclidean | :precomputed`
     * `linkage: :average | :complete | :single | :ward | :weighted`
 
-  Our current algorithm is $O(\\frac{n^2}{p} \\cdot \\log(n))$ where $n$ is the number of data points
-  and $p$ is the number of processors.
-  This is better than the generic algorithm which is $O(n^3)$.
-  It is also parallel, which means that runtime decreases in direct proportion to the number of
-  processors.
+  We use the nearest-neighbor-chain algorithm, which is $O(n^2)$ in both time and memory, where
+  $n$ is the number of data points.
+  This is better than the generic algorithm, which is $O(n^3)$, and is the best known bound for
+  this family of linkages.
 
   However, the implementation requires certain theoretical properties of the dissimilarities and
   linkages.
@@ -151,10 +150,10 @@ defmodule Scholar.Cluster.Hierarchical do
       iex> data = Nx.tensor([[2], [7], [9], [0], [3]])
       iex> Hierarchical.fit(data)
       %Scholar.Cluster.Hierarchical{
-        clades: Nx.tensor([[0, 4], [1, 2], [3, 5], [6, 7]]),
+        clades: Nx.tensor([[0, 4], [3, 5], [1, 2], [6, 7]]),
         dissimilarities: Nx.tensor([1.0, 2.0, 2.0, 4.0]),
         num_points: 5,
-        sizes: Nx.tensor([2, 2, 3, 5])
+        sizes: Nx.tensor([2, 3, 2, 5])
       }
 
   Passing the pairwise dissimilarities directly gives the same model:
@@ -163,10 +162,10 @@ defmodule Scholar.Cluster.Hierarchical do
       iex> dissimilarities = Scholar.Metrics.Distance.pairwise_euclidean(data)
       iex> Hierarchical.fit(dissimilarities, dissimilarity: :precomputed)
       %Scholar.Cluster.Hierarchical{
-        clades: Nx.tensor([[0, 4], [1, 2], [3, 5], [6, 7]]),
+        clades: Nx.tensor([[0, 4], [3, 5], [1, 2], [6, 7]]),
         dissimilarities: Nx.tensor([1.0, 2.0, 2.0, 4.0]),
         num_points: 5,
-        sizes: Nx.tensor([2, 2, 3, 5])
+        sizes: Nx.tensor([2, 3, 2, 5])
       }
   """
   deftransform fit(%Nx.Tensor{} = data, opts \\ []) do
@@ -195,7 +194,7 @@ defmodule Scholar.Cluster.Hierarchical do
       case linkage do
         # TODO: :centroid, :median
         l when l in [:average, :complete, :single, :ward, :weighted] ->
-          &parallel_nearest_neighbor/3
+          &nn_chain/3
       end
 
     n =
@@ -231,38 +230,122 @@ defmodule Scholar.Cluster.Hierarchical do
 
   # Clade functions
 
-  defnp parallel_nearest_neighbor(data, dissimilarity_fun, update_fun) do
+  # Nearest-neighbor-chain algorithm (Muellner, "Modern hierarchical, agglomerative
+  # clustering algorithms", 2011), the one SciPy uses for this same family of
+  # Lance-Williams-updatable linkages. Builds a chain of mutually-adjacent nearest
+  # neighbors (point -> its nearest -> that point's nearest -> ...), which is
+  # mathematically guaranteed to terminate in a pair that are each other's nearest
+  # neighbor (a chain can only ever cycle back on its immediate predecessor: three
+  # points a -> b -> c -> a would force d(c,a) < d(b,c) < d(a,b) <= d(a,c) = d(c,a),
+  # a contradiction). That pair merges, gets popped off the chain, and the chain
+  # continues extending from whatever is left, rather than restarting from scratch.
+  #
+  # Extending the chain by one point costs O(n) (a single row of the pairwise
+  # matrix). The total number of extensions over the whole run is O(n): a merge
+  # shortens the chain by 2, a non-terminating extension lengthens it by 1, and
+  # the chain can never exceed n, so extensions are amortized O(1) per merge. That
+  # makes the whole algorithm O(n^2) total, without relying on many clades being
+  # simultaneously mutual nearest neighbors of each other, which a round-based
+  # parallel merge needs for its own complexity to hold. That assumption stops
+  # holding once few enough clades remain: nearest-neighbor relationships form
+  # long chains rather than isolated mutual pairs, which is normal, not a bug in
+  # the data, but it means a round-based approach degrades to one merge per
+  # round for however many clades are left, each round still paying to scan the
+  # entire matrix. That is O(n) such rounds at O(n^2) each, i.e. O(n^3) overall,
+  # which is what this algorithm avoids.
+  #
+  # Reaching that O(n^2) in practice also depends on the pairwise matrix being
+  # updated in place across loop iterations. Copying it even once per merge would
+  # put the O(n^3) right back. Two things defeat the in-place update, both of them
+  # invisible in the source and both worth preserving as written below: reading a
+  # single cell of the matrix into another loop variable (which is why the merge
+  # distance is carried out of the chain loop instead of read back from the
+  # matrix), and writing the merged clade's row before its column rather than
+  # after.
+  defnp nn_chain(data, dissimilarity_fun, update_fun) do
     pairwise = dissimilarity_fun.(data)
     {n, _} = Nx.shape(pairwise)
     pairwise = Nx.broadcast(:infinity, {n}) |> Nx.make_diagonal() |> Nx.add(pairwise)
     clades = Nx.broadcast(-1, {n - 1, 2})
     sizes = Nx.broadcast(1, {2 * n - 1})
-    pointers = Nx.broadcast(-1, {2 * n - 2})
+    # Slot -> id of the clade currently living in it. Slots start out holding the
+    # singleton clades, and a merge overwrites the surviving slot with the new id.
+    pointers = Nx.iota({n})
 
     cluster_sizes = Nx.broadcast(1, {n})
     diss = Nx.tensor(:infinity, type: Nx.type(pairwise)) |> Nx.broadcast({n - 1})
+    alive = Nx.broadcast(Nx.u8(1), {n})
+    chain = Nx.broadcast(-1, {n})
 
     {{clades, diss, sizes, _cluster_sizes, count}, _} =
       while {{clades, diss, sizes, cluster_sizes, count = 0},
-             {pointers, pairwise, aborted = Nx.u8(0)}},
+             {pointers, pairwise, alive, chain, chain_length = 0, aborted = Nx.u8(0)}},
             count < n - 1 and aborted == 0 do
-        count_before_round = count
+        # Start a new chain from any live clade if the previous merge emptied it.
+        needs_start = chain_length == 0
+        start = Nx.argmax(alive)
 
-        # Indexes of who I am nearest to
-        nearest = Nx.argmin(pairwise, axis: 1)
+        chain =
+          Nx.select(
+            needs_start,
+            Nx.indexed_put(chain, Nx.reshape(0, {1, 1}), Nx.reshape(start, {1})),
+            chain
+          )
 
-        # Take who I am nearest to is nearest to
-        nearest_of_nearest = Nx.take(nearest, nearest)
+        chain_length = Nx.select(needs_start, 1, chain_length)
 
-        # If the entry is pointing back at me, then we are a clade
-        clades_selector = nearest_of_nearest == Nx.iota({n})
+        # Extend the chain until its last two entries are mutual nearest neighbors.
+        # Bounded by n: a real chain can never revisit a clade before terminating,
+        # so exceeding n extensions only happens with a non-finite dissimilarity
+        # (from NaN or infinite input), where argmin's tie-breaking can land on an
+        # already-dead clade and loop without ever finding a genuine mutual pair.
+        {chain, chain_length, found, _steps, merge_diss, _pairwise, _alive} =
+          while {chain, chain_length, found = Nx.u8(0), steps = 0,
+                 _chain_diss = Nx.Constants.infinity(Nx.type(pairwise)), pairwise, alive},
+                found == 0 and steps <= n do
+            tip = chain[chain_length - 1]
+            previous = Nx.select(chain_length > 1, chain[Nx.max(chain_length - 2, 0)], -1)
 
-        # Now let's get the links that form clades.
-        # They are bidirectional but let's keep only one side.
-        links = Nx.select(clades_selector and nearest > nearest_of_nearest, nearest, n)
+            # Merged-away clades are masked out here rather than overwritten in the
+            # matrix: this costs O(n) per step, whereas blanking their row and
+            # column would cost a full n x n rewrite on every merge.
+            row = Nx.select(alive, pairwise[tip], Nx.Constants.infinity(Nx.type(pairwise)))
+            nearest = Nx.argmin(row)
 
-        {clades, count, pointers, pairwise, diss, sizes, cluster_sizes} =
-          merge_clades(
+            # Distance to that neighbor, carried out so that the merge below does
+            # not have to read it back out of the matrix. That read looks free but
+            # is not: feeding a cell of the matrix into another loop variable stops
+            # XLA from updating the matrix in place, costing a full n x n copy on
+            # every merge. See the note above nn_chain/3.
+            chain_diss = Nx.reduce_min(row)
+
+            # A point is never its own nearest neighbor, but argmin cannot tell the
+            # difference once a row is entirely non-finite: the diagonal is always
+            # infinity by construction, same as every dead or genuinely
+            # infinitely-far entry, so a tie-break can land right back on tip. That
+            # is only possible with a non-finite dissimilarity (see the module
+            # comment above); treat it as stalled rather than let the chain merge a
+            # clade with itself.
+            self_match = nearest == tip
+            found = nearest == previous and not self_match
+
+            chain =
+              Nx.select(
+                found or self_match,
+                chain,
+                Nx.indexed_put(chain, Nx.reshape(chain_length, {1, 1}), Nx.reshape(nearest, {1}))
+              )
+
+            chain_length = Nx.select(found or self_match, chain_length, chain_length + 1)
+            steps = Nx.select(self_match, n + 1, steps + 1)
+            {chain, chain_length, found, steps, chain_diss, pairwise, alive}
+          end
+
+        i = Nx.max(Nx.min(chain[chain_length - 1], chain[Nx.max(chain_length - 2, 0)]), 0)
+        j = Nx.max(Nx.max(chain[chain_length - 1], chain[Nx.max(chain_length - 2, 0)]), 0)
+
+        {clades, count, pointers, pairwise, diss, sizes, cluster_sizes, alive} =
+          merge_one(
             clades,
             count,
             pointers,
@@ -270,23 +353,25 @@ defmodule Scholar.Cluster.Hierarchical do
             diss,
             sizes,
             cluster_sizes,
-            links,
+            alive,
+            i,
+            j,
+            found,
+            merge_diss,
             n,
             update_fun
           )
 
-        # Non-finite dissimilarities (from NaN or infinite input) can make argmin's
-        # tie-breaking point two clades at each other asymmetrically, so that neither
-        # is ever picked as the other's mutual nearest neighbor and no merge happens.
-        # That is otherwise impossible: for finite dissimilarities the globally closest
-        # pair of live clades is always mutually nearest, guaranteeing progress every
-        # round, which is why this never triggers on well formed input (count changing
-        # is the only thing checked, so it costs nothing when it doesn't apply). When it
-        # does happen, stop instead of guessing a merge: the two clades are stuck exactly
-        # because there is no finite distance to justify pairing them over any other.
-        aborted = count == count_before_round
+        chain_length = Nx.select(found, chain_length - 2, chain_length)
 
-        {{clades, diss, sizes, cluster_sizes, count}, {pointers, pairwise, aborted}}
+        # A non-finite dissimilarity is the only way the chain extension above can
+        # exhaust its step budget without finding a mutual pair. Stop instead of
+        # looping forever or guessing a merge that has no finite distance to
+        # justify it: see the comment on the incomplete-rows handling below.
+        aborted = found == 0
+
+        {{clades, diss, sizes, cluster_sizes, count},
+         {pointers, pairwise, alive, chain, chain_length, aborted}}
       end
 
     sizes = sizes[n..(2 * n - 2)]
@@ -313,11 +398,15 @@ defmodule Scholar.Cluster.Hierarchical do
     # Their clade ids stay -1 rather than being mapped through the table.
     sorted_clades = clades[perm]
 
+    # Each row already holds [min, max] in terms of the ids merge_one saw, but remapping
+    # ids to their final, sorted-by-dissimilarity numbering does not preserve that order when
+    # two rows are tied: the mapping is a permutation of ids, not a monotonic one on ties. Sort
+    # again after remapping so a row is always [min, max] in the ids callers actually see.
     clades =
       Nx.select(
         Nx.broadcast(Nx.new_axis(incomplete, -1), Nx.shape(sorted_clades)),
         -1,
-        Nx.take(clade_id_mapping, Nx.max(sorted_clades, 0))
+        Nx.take(clade_id_mapping, Nx.max(sorted_clades, 0)) |> Nx.sort(axis: 1)
       )
 
     sizes = Nx.select(incomplete, 0, sizes[perm])
@@ -325,7 +414,13 @@ defmodule Scholar.Cluster.Hierarchical do
     {clades, diss[perm], sizes}
   end
 
-  defnp merge_clades(
+  # Merges clades i and j (or does nothing if `found` is false, which only happens when
+  # the chain above stalled on a non-finite dissimilarity). Always does exactly the O(n)
+  # work of one merge, rather than scanning every one of the n possible pairs to find the
+  # (at most one) real one: nn_chain only ever has one pair to merge per call, unlike the
+  # round-based approach this replaced, which could have many simultaneously and needed
+  # that scan.
+  defnp merge_one(
           clades,
           count,
           pointers,
@@ -333,71 +428,80 @@ defmodule Scholar.Cluster.Hierarchical do
           diss,
           sizes,
           cluster_sizes,
-          links,
+          alive,
+          i,
+          j,
+          found,
+          merge_diss,
           n,
           update_fun
         ) do
-    {{clades, count, pointers, pairwise, diss, sizes, cluster_sizes}, _} =
-      while {{clades, count, pointers, pairwise, diss, sizes, cluster_sizes}, links},
-            i <- 0..(Nx.size(links) - 1) do
-        # i < j because of how links is formed.
-        # i will become the new clade index and we "infinity-out" j.
-        j = links[i]
+    indices = [i, j] |> Nx.stack() |> Nx.new_axis(-1)
+    a = pointers[i]
+    b = pointers[j]
+    c = count + n
 
-        if j == n do
-          {{clades, count, pointers, pairwise, diss, sizes, cluster_sizes}, links}
-        else
-          # Clades a and b (i and j of pairwise) are being merged into c.
-          indices = [i, j] |> Nx.stack() |> Nx.new_axis(-1)
-          a = find_clade(pointers, i)
-          b = find_clade(pointers, j)
-          c = count + n
+    new_clade = Nx.stack([a, b]) |> Nx.sort() |> Nx.new_axis(0)
+    clades = Nx.select(found, Nx.put_slice(clades, [count, 0], new_clade), clades)
 
-          # Update clades
-          new_clade = Nx.stack([a, b]) |> Nx.sort() |> Nx.new_axis(0)
-          clades = Nx.put_slice(clades, [count, 0], new_clade)
+    sa = sizes[i]
+    sb = sizes[j]
+    sc = sa + sb
 
-          # Update sizes
-          sa = sizes[i]
-          sb = sizes[j]
-          sc = sa + sb
-          sizes = Nx.indexed_put(sizes, Nx.stack([i, c]) |> Nx.new_axis(-1), Nx.stack([sc, sc]))
+    sizes =
+      Nx.select(
+        found,
+        Nx.indexed_put(sizes, Nx.stack([i, c]) |> Nx.new_axis(-1), Nx.stack([sc, sc])),
+        sizes
+      )
 
-          cluster_sizes =
-            Nx.indexed_put(cluster_sizes, Nx.stack([i, j]) |> Nx.new_axis(-1), Nx.stack([sc, sc]))
+    cluster_sizes =
+      Nx.select(
+        found,
+        Nx.indexed_put(cluster_sizes, Nx.stack([i, j]) |> Nx.new_axis(-1), Nx.stack([sc, sc])),
+        cluster_sizes
+      )
 
-          # Update dissimilarities
-          diss = Nx.indexed_put(diss, Nx.stack([count]), pairwise[i][j])
+    diss = Nx.select(found, Nx.indexed_put(diss, Nx.stack([count]), merge_diss), diss)
 
-          # Update pointers
-          pointers = Nx.indexed_put(pointers, indices, Nx.stack([c, c]))
+    # Only i survives the merge, so only its slot has to point at the new clade.
+    pointers =
+      Nx.select(
+        found,
+        Nx.indexed_put(pointers, Nx.reshape(i, {1, 1}), Nx.reshape(c, {1})),
+        pointers
+      )
 
-          # Update pairwise
-          updates =
-            update_fun.(pairwise[i], pairwise[j], pairwise[i][j], sa, sb, cluster_sizes)
-            |> Nx.indexed_put(indices, Nx.broadcast(:infinity, {2}))
+    # j is no longer a live clade; i now stands for the merged one.
+    alive_after_j_dies =
+      Nx.indexed_put(
+        alive,
+        Nx.reshape(j, {1, 1}),
+        Nx.broadcast(0, {1}) |> Nx.as_type(Nx.type(alive))
+      )
 
-          pairwise =
-            pairwise
-            |> Nx.put_slice([i, 0], Nx.reshape(updates, {1, n}))
-            |> Nx.put_slice([0, i], Nx.reshape(updates, {n, 1}))
-            |> Nx.put_slice([j, 0], Nx.broadcast(:infinity, {1, n}))
-            |> Nx.put_slice([0, j], Nx.broadcast(:infinity, {n, 1}))
+    alive = Nx.select(found, alive_after_j_dies, alive)
 
-          {{clades, count + 1, pointers, pairwise, diss, sizes, cluster_sizes}, links}
-        end
-      end
+    updates =
+      update_fun.(pairwise[i], pairwise[j], merge_diss, sa, sb, cluster_sizes)
+      |> Nx.indexed_put(indices, Nx.broadcast(:infinity, {2}))
 
-    {clades, count, pointers, pairwise, diss, sizes, cluster_sizes}
-  end
+    # Only the surviving clade's row and column are rewritten; j's are left stale
+    # and masked out through `alive` when the chain reads a row. Unguarded on
+    # purpose: when there is no pair to merge the caller aborts on this same
+    # iteration and discards `pairwise`, so writing to it is harmless, whereas
+    # guarding it with Nx.select would force a full n x n copy on every merge.
+    # Column first, then row. The order is not cosmetic: writing the row first
+    # and the column second makes XLA fall back to copying the whole matrix on
+    # every merge, which is O(n^3) overall. See the comment above nn_chain/3.
+    pairwise =
+      pairwise
+      |> Nx.put_slice([0, i], Nx.reshape(updates, {n, 1}))
+      |> Nx.put_slice([i, 0], Nx.reshape(updates, {1, n}))
 
-  defnp find_clade(pointers, i) do
-    {i, _, _} =
-      while {_current = i, next = pointers[i], pointers}, next != -1 do
-        {next, pointers[next], pointers}
-      end
+    count = Nx.select(found, count + 1, count)
 
-    i
+    {clades, count, pointers, pairwise, diss, sizes, cluster_sizes, alive}
   end
 
   # Dissimilarity update functions

--- a/test/scholar/cluster/hierarchical_test.exs
+++ b/test/scholar/cluster/hierarchical_test.exs
@@ -20,28 +20,31 @@ defmodule Scholar.Cluster.HierarchicalTest do
       data = Nx.tensor([[1, 5], [2, 5], [1, 4], [4, 5], [5, 5], [5, 4], [1, 2], [1, 1], [2, 1]])
 
       # This diagram represents the sequence of expected merges. The data starts off with all
-      # points as singleton clades. The first step of the algorithm merges singleton clades
-      # 0: [0] and 1: [1] to form clade 9: [0, 1]. This process continues until all clades have
-      # been merged into a single clade with all points.
+      # points as singleton clades. The algorithm builds a chain of nearest neighbors (a point,
+      # its nearest neighbor, that neighbor's nearest, ...) and merges as soon as the last two
+      # entries in the chain are each other's nearest neighbor, then keeps extending the same
+      # chain from what is left rather than restarting. That is why, below, clade 9: [0, 1]
+      # immediately pulls in point 2 (its nearest neighbor is now clade 9) before the algorithm
+      # moves on to points 3 and 4, rather than growing every clade one round at a time.
       #
       #       0   1   2   3   4   5   6   7   8
       #    8: [0] [1] [2] [3] [4] [5] [6] [7] [8]
       #       9    2   3   4   5   6   7   8
       #    9: [01] [2] [3] [4] [5] [6] [7] [8]
       #       ----
-      #       9    2   10   5   6   7   8
-      #   10: [01] [2] [34] [5] [6] [7] [8]
-      #                ----
-      #       9    2   10   5   11   8
-      #   11: [01] [2] [34] [5] [67] [8]
-      #                         ----
-      #       12    10   5   11   8
-      #   12: [012] [34] [5] [67] [8]
+      #       10   3   4   5   6   7   8
+      #   10: [012] [3] [4] [5] [6] [7] [8]
       #       -----
-      #       12    13    11   8
-      #   13: [012] [345] [67] [8]
+      #       10    11   5   6   7   8
+      #   11: [012] [34] [5] [6] [7] [8]
+      #                ----
+      #       10    12    6   7   8
+      #   12: [012] [345] [6] [7] [8]
       #             -----
-      #       12    13    14
+      #       10    12    13   8
+      #   13: [012] [345] [67] [8]
+      #                    ----
+      #       10    12    14
       #   14: [012] [345] [678]
       #                   -----
       #       15       14
@@ -57,19 +60,19 @@ defmodule Scholar.Cluster.HierarchicalTest do
       assert model.clades ==
                Nx.tensor([
                  [0, 1],
-                 [3, 4],
-                 [6, 7],
                  [2, 9],
-                 [5, 10],
-                 [8, 11],
-                 [12, 13],
+                 [3, 4],
+                 [5, 11],
+                 [6, 7],
+                 [8, 13],
+                 [10, 12],
                  [14, 15]
                ])
 
       assert model.dissimilarities ==
                Nx.tensor([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0])
 
-      assert model.sizes == Nx.tensor([2, 2, 2, 3, 3, 3, 6, 9])
+      assert model.sizes == Nx.tensor([2, 3, 2, 3, 2, 3, 6, 9])
 
       # The clustering part of the algorithm uses the `cluster_by: [num_clusters: 3]` option to
       # take the model and form 3 clusters.
@@ -177,9 +180,9 @@ defmodule Scholar.Cluster.HierarchicalTest do
 
     test "cluster by number of clusters", %{model: model} do
       labels_map = Hierarchical.labels_map(model, cluster_by: [num_clusters: 3])
-      assert labels_map == %{0 => [0, 4], 1 => [1, 2], 2 => [3]}
+      assert labels_map == %{0 => [0, 3, 4], 1 => [1], 2 => [2]}
       labels_list = Hierarchical.labels_list(model, cluster_by: [num_clusters: 3])
-      assert labels_list == [0, 1, 1, 2, 0]
+      assert labels_list == [0, 1, 2, 0, 0]
     end
 
     test "remaps clade ids after sorting dendrogram rows" do
@@ -196,6 +199,33 @@ defmodule Scholar.Cluster.HierarchicalTest do
       labels = Hierarchical.labels_list(model, cluster_by: [num_clusters: 5])
       assert length(labels) == 50
       assert labels |> Enum.uniq() |> length() == 5
+    end
+
+    test "tied merge heights still leave every dendrogram row in ascending order" do
+      # Duplicate points force merges to tie. Remapping clade ids to their final,
+      # sorted-by-dissimilarity numbering is a permutation, not a monotonic one, so
+      # on a tie it can swap the two children of a row and leave it descending.
+      data =
+        Nx.tensor([
+          [0.0, 0.0],
+          [0.0, 1.0],
+          [0.0, 0.0],
+          [1.0, 1.0],
+          [1.0, 0.0],
+          [1.0, 1.0],
+          [2.0, 0.0],
+          [2.0, 1.0]
+        ])
+
+      model = Hierarchical.fit(data, linkage: :complete)
+
+      assert model.dissimilarities |> Nx.to_flat_list() |> Enum.uniq() |> length() <
+               model.num_points - 1,
+             "expected tied merge heights, which is what this test is about"
+
+      assert model.clades
+             |> Nx.to_list()
+             |> Enum.all?(fn [left, right] -> left < right end)
     end
   end
 
@@ -322,6 +352,26 @@ defmodule Scholar.Cluster.HierarchicalTest do
       assert model.num_points == 6
       assert Nx.to_number(Nx.all(Nx.not_equal(model.clades, -1))) == 1
       assert Nx.to_number(Nx.all(Nx.greater(model.sizes, 0))) == 1
+    end
+
+    test "several unreachable clades report every merge that could not be made" do
+      # Only 0 and 1 have a finite distance to anything. Points 2 and 3 are infinitely
+      # far from everyone including each other, so two of the three merges have nothing
+      # to justify them, not just the last one.
+      d =
+        Nx.tensor([
+          [0.0, 1.0, :infinity, :infinity],
+          [1.0, 0.0, :infinity, :infinity],
+          [:infinity, :infinity, 0.0, :infinity],
+          [:infinity, :infinity, :infinity, 0.0]
+        ])
+
+      model = Hierarchical.fit(d, dissimilarity: :precomputed, linkage: :single)
+
+      assert Nx.to_flat_list(model.sizes) == [2, 0, 0]
+      assert Nx.to_flat_list(model.dissimilarities) |> Enum.take(1) == [1.0]
+      assert Nx.to_number(Nx.all(Nx.is_nan(model.dissimilarities[1..2]))) == 1
+      assert Nx.to_flat_list(model.clades[1..2]) == [-1, -1, -1, -1]
     end
   end
 


### PR DESCRIPTION
`Hierarchical.fit` scales close to $O(n^3)$ in practice rather than the documented $O(\frac{n^2}{p} \cdot \log n)$.

The round-based merge assumes $O(\log n)$ rounds, which only holds while many clades are simultaneously each other's nearest neighbor. Once few enough clades remain, nearest-neighbor relationships form long chains instead of isolated mutual pairs, so it settles into one merge per round while every round still runs `Nx.argmin` over the whole matrix. That is $O(n)$ rounds at $O(n^2)$ each.

The practical effect is that the module is unusable past a few hundred points. `Scholar.Cluster.HDBSCAN` (#352) calls `Hierarchical.fit` internally and inherits the same ceiling.

This replaces the round-based merge with the nearest-neighbor-chain algorithm (Müllner 2011), which SciPy uses for this same family of Lance-Williams-updatable linkages. It extends a chain of nearest neighbors and merges as soon as the last two entries are each other's nearest, so each step scans one row instead of the whole matrix, and the number of steps is amortized $O(n)$ over the run. Measured with EXLA on random data:

| n | before | after |
|---|--------|-------|
| 400 | 1.5s | 0.13s |
| 800 | 28.8s | 0.13s |
| 1600 | 545.9s | 0.17s |

Reaching that in practice also depends on the pairwise matrix being updated in place across loop iterations, and two things quietly defeat it and bring the cubic behaviour back. Both are commented where they appear: reading a single cell of the matrix into another loop variable, and writing the merged clade's row before its column rather than after.

This also fixes a latent bug where remapping clade ids could leave a `clades` row in descending order when two merges tie, since the remapping is a permutation of ids and is not monotonic on ties.

Merge order at tied dissimilarities changes, as it has to with a different algorithm. The heights are the same; what differs is which of several equally valid merges happens first, which can shift clade ids and, where a cut falls inside a run of tied merges, the partition `labels_list/2` returns.

Verified against `scipy.cluster.hierarchy.linkage` over 600 configurations (5 linkages, 3 data shapes, 8 seeds, 3 sizes, f32 and f64): f64 matches exactly, and f32 deviates only in the cases where the implementation this replaces already deviates.
