### PR TITLE
Fix tied nearest neighbors merging a clade twice

### DIFF
--- a/lib/scholar/cluster/hierarchical.ex
+++ b/lib/scholar/cluster/hierarchical.ex
@@ -295,10 +295,12 @@ defmodule Scholar.Cluster.Hierarchical do
         chain_length = Nx.select(needs_start, 1, chain_length)
 
         # Extend the chain until its last two entries are mutual nearest neighbors.
-        # Bounded by n: a real chain can never revisit a clade before terminating,
-        # so exceeding n extensions only happens with a non-finite dissimilarity
-        # (from NaN or infinite input), where argmin's tie-breaking can land on an
-        # already-dead clade and loop without ever finding a genuine mutual pair.
+        # Bounded by n: the distance along a chain strictly decreases, so a chain
+        # can never revisit a clade before terminating, provided ties end it rather
+        # than extend it (see `previous_is_nearest` below). Exceeding n extensions
+        # then only happens with a non-finite dissimilarity (from NaN or infinite
+        # input), where argmin's tie-breaking can land on an already-dead clade and
+        # loop without ever finding a genuine mutual pair.
         {chain, chain_length, found, _steps, merge_diss, _pairwise, _alive} =
           while {chain, chain_length, found = Nx.u8(0), steps = 0,
                  _chain_diss = Nx.Constants.infinity(Nx.type(pairwise)), pairwise, alive},
@@ -327,17 +329,44 @@ defmodule Scholar.Cluster.Hierarchical do
             # comment above); treat it as stalled rather than let the chain merge a
             # clade with itself.
             self_match = nearest == tip
-            found = nearest == previous and not self_match
+
+            # The chain terminates whenever the previous entry is *a* nearest
+            # neighbor of the tip, not only when it is the one argmin happens to
+            # return. The two differ exactly when the tip's nearest distance is
+            # tied, and preferring the previous entry there is what keeps the
+            # chain from walking back onto a clade it already holds: a duplicated
+            # entry survives the merge that pops its other occurrence, and is then
+            # merged a second time, after it is already gone. The chain can only
+            # cycle back on its immediate predecessor while distances strictly
+            # decrease, which ties break.
+            previous_is_nearest =
+              chain_length > 1 and
+                Nx.take(row, Nx.max(previous, 0)) == chain_diss
+
+            # `nearest == previous` on its own would miss a tie, and comparing the
+            # distances on its own would miss a NaN, which is never equal to
+            # itself. Either one ending the chain is enough.
+            found = (previous_is_nearest or nearest == previous) and not self_match
+
+            # The chain holds live clades and so cannot outgrow its buffer, but a
+            # non-finite dissimilarity can stall it without ever finding a pair, and
+            # a write past the end would otherwise be silently clamped onto the last
+            # slot. Treat it as stalled, like a self match.
+            stalled = self_match or chain_length >= n
 
             chain =
               Nx.select(
-                found or self_match,
+                found or stalled,
                 chain,
-                Nx.indexed_put(chain, Nx.reshape(chain_length, {1, 1}), Nx.reshape(nearest, {1}))
+                Nx.indexed_put(
+                  chain,
+                  Nx.reshape(Nx.min(chain_length, n - 1), {1, 1}),
+                  Nx.reshape(nearest, {1})
+                )
               )
 
-            chain_length = Nx.select(found or self_match, chain_length, chain_length + 1)
-            steps = Nx.select(self_match, n + 1, steps + 1)
+            chain_length = Nx.select(found or stalled, chain_length, chain_length + 1)
+            steps = Nx.select(stalled, n + 1, steps + 1)
             {chain, chain_length, found, steps, chain_diss, pairwise, alive}
           end
 

--- a/lib/scholar/cluster/hierarchical.ex
+++ b/lib/scholar/cluster/hierarchical.ex
@@ -550,8 +550,17 @@ defmodule Scholar.Cluster.Hierarchical do
   defnp single(dac, dbc, _dab, _sa, _sb, _sc),
     do: Nx.min(dac, dbc)
 
+  # The clamp is not cosmetic. Merged clades are masked out through `alive` rather
+  # than blanked out of the matrix, so their rows keep stale values that this still
+  # reads for the dead columns, where the term above can come out negative. Those
+  # columns are never used, but the square root of a negative raises on the binary
+  # backend, so it has to stay finite. It also absorbs a term that rounds just below
+  # zero, which is possible here even on live columns.
   defnp ward(dac, dbc, dab, sa, sb, sk),
-    do: Nx.sqrt(((sa + sk) * dac ** 2 + (sb + sk) * dbc ** 2 - sk * dab ** 2) / (sa + sb + sk))
+    do:
+      Nx.sqrt(
+        Nx.max(((sa + sk) * dac ** 2 + (sb + sk) * dbc ** 2 - sk * dab ** 2) / (sa + sb + sk), 0)
+      )
 
   defnp weighted(dac, dbc, _dab, _sa, _sb, _sc),
     do: (dac + dbc) / 2

--- a/test/scholar/cluster/hierarchical_test.exs
+++ b/test/scholar/cluster/hierarchical_test.exs
@@ -227,6 +227,44 @@ defmodule Scholar.Cluster.HierarchicalTest do
              |> Nx.to_list()
              |> Enum.all?(fn [left, right] -> left < right end)
     end
+
+    test "tied nearest neighbors still merge every point exactly once" do
+      # Integer coordinates over a small range, so distances tie constantly and a
+      # clade's nearest neighbor is very often not unique. The chain extension can
+      # then walk back onto a clade it already holds, and the duplicate outlives the
+      # merge that consumed it, so it gets merged a second time: a clade is used
+      # twice, the sizes stop adding up, and the tree never closes over every point.
+      data =
+        Nx.tensor([
+          [0.0, 2.0, 2.0],
+          [1.0, 3.0, 1.0],
+          [2.0, 3.0, 1.0],
+          [0.0, 0.0, 0.0],
+          [0.0, 1.0, 3.0],
+          [3.0, 0.0, 3.0],
+          [1.0, 1.0, 1.0],
+          [1.0, 1.0, 3.0],
+          [2.0, 2.0, 1.0],
+          [1.0, 0.0, 1.0],
+          [1.0, 1.0, 3.0],
+          [1.0, 0.0, 0.0],
+          [3.0, 2.0, 3.0],
+          [0.0, 3.0, 1.0],
+          [1.0, 1.0, 0.0],
+          [3.0, 2.0, 3.0],
+          [2.0, 0.0, 0.0],
+          [0.0, 1.0, 0.0]
+        ])
+
+      model = Hierarchical.fit(data, linkage: :single)
+
+      # The last merge has to gather every point.
+      assert Nx.to_number(model.sizes[-1]) == model.num_points
+
+      # And no clade may be merged into two different parents.
+      children = model.clades |> Nx.to_flat_list()
+      assert length(children) == children |> Enum.uniq() |> length()
+    end
   end
 
   describe "precomputed dissimilarity" do

--- a/test/scholar/cluster/hierarchical_test.exs
+++ b/test/scholar/cluster/hierarchical_test.exs
@@ -164,6 +164,28 @@ defmodule Scholar.Cluster.HierarchicalTest do
                  4.1218791007995605
                ])
     end
+
+    test "ward does not take the square root of a negative number" do
+      # Merged clades are masked out of the matrix rather than blanked, so their
+      # rows keep stale values that ward's update still reads. The Lance-Williams
+      # term can then go negative for a dead column, and the square root of that
+      # raises on the binary backend and is a silent NaN under EXLA.
+      data =
+        Nx.tensor([
+          [0.0, 0.0],
+          [2.0, 1.0],
+          [2.0, 0.0],
+          [2.0, 1.0],
+          [2.0, 1.0],
+          [1.0, 1.0],
+          [1.0, 0.0],
+          [0.0, 2.0]
+        ])
+
+      model = Hierarchical.fit(data, linkage: :ward)
+
+      refute model.dissimilarities |> Nx.is_nan() |> Nx.any() |> Nx.to_number() == 1
+    end
   end
 
   describe "cluster labels" do

--- a/test/scholar/cluster/hierarchical_test.exs
+++ b/test/scholar/cluster/hierarchical_test.exs
@@ -401,6 +401,34 @@ defmodule Scholar.Cluster.HierarchicalTest do
       assert Nx.to_number(model.sizes[-1]) == 0
     end
 
+    test "an infinite coordinate does not run the chain past the end of its buffer" do
+      # An infinite coordinate puts both :infinity and :nan in the distance matrix, since
+      # subtracting infinities gives NaN. The chain can then keep extending without ever
+      # finding a mutual pair, and walking past the end of its own buffer raises instead
+      # of reporting the merges it could not make.
+      x = Nx.tensor([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [:infinity, 0.0]])
+
+      model = Hierarchical.fit(x, linkage: :complete)
+
+      assert model.num_points == 4
+      assert Nx.shape(model.clades) == {3, 2}
+
+      # Whatever it did merge is still a well formed tree: no clade merged twice, and no
+      # row naming a clade that is not born yet.
+      made =
+        Nx.to_flat_list(model.clades)
+        |> Enum.chunk_every(2)
+        |> Enum.zip(Nx.to_flat_list(model.sizes))
+        |> Enum.reject(fn {_pair, size} -> size == 0 end)
+
+      children = Enum.flat_map(made, fn {pair, _size} -> pair end)
+      assert children == Enum.uniq(children)
+
+      assert Enum.all?(Enum.with_index(made), fn {{[a, b], _size}, k} ->
+               a < model.num_points + k and b < model.num_points + k
+             end)
+    end
+
     test "a NaN coordinate still makes every merge" do
       # NaN alone does not stall the loop: argmin keeps picking a mutual pair, so every
       # merge is made. The dissimilarities really are NaN here, since the distances are,


### PR DESCRIPTION
`Hierarchical.fit` can merge a clade twice when nearest neighbor distances tie. The result is a malformed tree: a clade ends up as the child of two different parents, the sizes stop adding up, and the root no longer gathers every point.

The nearest neighbor chain is only guaranteed to terminate on a mutual pair while the distance along it strictly decreases, and that is also what stops it from ever revisiting a clade it already holds. Ties break the guarantee. The chain ended only when `argmin` happened to return the previous entry, so on a tie it could walk past that entry and back onto a clade already on the chain. The duplicate then outlives the merge that consumes its other occurrence and is merged a second time, after it is already dead.

The chain now ends whenever the previous entry is *a* nearest neighbor of the tip, not only when it is the one `argmin` returns, which restores the strict decrease. Comparing the distances alone would miss a `NaN`, which is never equal to itself, so either condition ending the chain is enough. Writing past the end of the chain buffer is guarded too, since `Nx.indexed_put` clamps an out of range index rather than raising.

Introduced in #355. Measured over 200,000 random fits on integer coordinates, where distances tie constantly: 38 malformed trees before, 0 after. The regression test fails on the current implementation.

`linkage: :ward` also raises on the binary backend, and is fixed here too. Merged clades are masked out of the matrix rather than blanked, so their rows keep stale values that ward's update still reads, and its Lance-Williams term can come out negative for a dead column. Those columns are never used, but the square root of a negative raises where EXLA gives a silent NaN, so the term is clamped at zero. Also introduced in #355: 17 crashes in 600 random fits before, 0 after.

The chain guard also covers a third case from #355: an infinite coordinate puts both infinity and NaN in the distance matrix, the chain then extends without ever finding a mutual pair, and writing past the end of its buffer raised `index 4 is out of bounds` on every linkage. It now reports the merges it could not make, as the moduledoc describes.
