### PR TITLE
Fix KNNImputer wrong donors for multi-NaN rows and f64 crash

### DIFF
--- a/lib/scholar/impute/knn_imputter.ex
+++ b/lib/scholar/impute/knn_imputter.ex
@@ -199,17 +199,12 @@ defmodule Scholar.Impute.KNNImputter do
     # minus nan column
     coordinates = coordinates - 1
 
-    # a donor with no value in nan_col cannot be used to fill it - this also
-    # rules out the row itself as its own neighbor, since the row's value at
-    # nan_col is NaN by construction (that's what we're trying to impute)
+    # a donor missing nan_col is unusable, which also rules out the row itself
     if Nx.is_nan(potential_neighbor[nan_col]) do
       Nx.Constants.infinity(Nx.type(row))
     else
-      # columns usable for the comparison: present in both row and donor,
-      # excluding nan_col. Any OTHER missing value in either row (row can
-      # have more than one NaN, not just nan_col) must be excluded here too,
-      # or it poisons the sum with NaN and every donor ends up looking
-      # equally (infinitely) far, regardless of how close it really is.
+      # exclude any column where either row is NaN, not just nan_col, or a
+      # second missing value poisons the distance for every donor
       usable =
         row
         |> Nx.is_nan()
@@ -219,8 +214,6 @@ defmodule Scholar.Impute.KNNImputter do
 
       present_coordinates = Nx.sum(usable)
 
-      # if row and donor share no other valid column, the donor gives no
-      # information about this row and must not be picked as a neighbor
       if present_coordinates == 0 do
         Nx.Constants.infinity(Nx.type(row))
       else

--- a/lib/scholar/impute/knn_imputter.ex
+++ b/lib/scholar/impute/knn_imputter.ex
@@ -199,49 +199,36 @@ defmodule Scholar.Impute.KNNImputter do
     # minus nan column
     coordinates = coordinates - 1
 
-    # inputes zeros in nan_col to calculate distance with squared_euclidean
-    new_row = Nx.indexed_put(row, Nx.new_axis(nan_col, 0), Nx.tensor(0))
+    # a donor with no value in nan_col cannot be used to fill it - this also
+    # rules out the row itself as its own neighbor, since the row's value at
+    # nan_col is NaN by construction (that's what we're trying to impute)
+    if Nx.is_nan(potential_neighbor[nan_col]) do
+      Nx.Constants.infinity(Nx.type(row))
+    else
+      # columns usable for the comparison: present in both row and donor,
+      # excluding nan_col. Any OTHER missing value in either row (row can
+      # have more than one NaN, not just nan_col) must be excluded here too,
+      # or it poisons the sum with NaN and every donor ends up looking
+      # equally (infinitely) far, regardless of how close it really is.
+      usable =
+        row
+        |> Nx.is_nan()
+        |> Nx.logical_or(Nx.is_nan(potential_neighbor))
+        |> Nx.logical_not()
+        |> Nx.indexed_put(Nx.new_axis(nan_col, 0), Nx.tensor(0, type: :u8))
 
-    # if potential neighbor has nan in nan_col, we don't want to calculate distance and the case if potential_neighbour is the row to impute
-    {potential_neighbor} =
-      if Nx.is_nan(potential_neighbor[nan_col]) do
-        potential_neighbor =
-          Nx.broadcast(Nx.Constants.infinity(Nx.type(potential_neighbor)), potential_neighbor)
+      present_coordinates = Nx.sum(usable)
 
-        {potential_neighbor}
-      else
-        # inputes zeros in nan_col to calculate distance with squared_euclidean - distance will be 0 so no change to the distance value
-        potential_neighbor =
-          Nx.indexed_put(
-            potential_neighbor,
-            Nx.new_axis(nan_col, 0),
-            Nx.tensor(0, type: Nx.type(row))
-          )
-
-        {potential_neighbor}
-      end
-
-    # calculates how many values are present in the row without nan_col to calculate weight for the distance
-    present_coordinates = Nx.sum(Nx.logical_not(Nx.is_nan(potential_neighbor))) - 1
-
-    # if row has all nans we skip it
-    {weight, potential_neighbor} =
+      # if row and donor share no other valid column, the donor gives no
+      # information about this row and must not be picked as a neighbor
       if present_coordinates == 0 do
-        potential_neighbor =
-          Nx.broadcast(Nx.Constants.infinity(Nx.type(potential_neighbor)), potential_neighbor)
-
-        weight = 0
-        {weight, potential_neighbor}
+        Nx.Constants.infinity(Nx.type(row))
       else
-        potential_neighbor = Nx.select(Nx.is_nan(potential_neighbor), new_row, potential_neighbor)
+        masked_row = Nx.select(usable, row, 0)
+        masked_neighbor = Nx.select(usable, potential_neighbor, 0)
         weight = coordinates / present_coordinates
-        {weight, potential_neighbor}
+        Nx.sqrt(weight * squared_euclidean(masked_row, masked_neighbor))
       end
-
-    # calculating weighted euclidian distance
-    distance = Nx.sqrt(weight * squared_euclidean(new_row, potential_neighbor))
-
-    # return inf if potential_row is row to impute
-    Nx.select(Nx.is_nan(distance), Nx.Constants.infinity(Nx.type(distance)), distance)
+    end
   end
 end

--- a/lib/scholar/impute/knn_imputter.ex
+++ b/lib/scholar/impute/knn_imputter.ex
@@ -124,7 +124,7 @@ defmodule Scholar.Impute.KNNImputter do
     {num_rows, num_cols} = Nx.shape(x)
     num_neighbors = opts[:num_neighbors]
 
-    placeholder_value = Nx.tensor(:nan)
+    placeholder_value = Nx.tensor(:nan, type: Nx.type(x))
 
     values_to_impute = Nx.broadcast(placeholder_value, x)
 
@@ -160,7 +160,7 @@ defmodule Scholar.Impute.KNNImputter do
     rows = opts[:rows]
     num_neighbors = opts[:num_neighbors]
 
-    row_distances = Nx.iota({rows}, type: {:f, 32})
+    row_distances = Nx.iota({rows}, type: Nx.type(x))
 
     row_with_value_to_fill = x[nan_row]
 

--- a/test/scholar/impute/knn_imputter_test.exs
+++ b/test/scholar/impute/knn_imputter_test.exs
@@ -21,10 +21,7 @@ defmodule KNNImputterTest do
 
       assert missing_values == :nan
 
-      # row 3 has three missing values (cols 0, 1, 2), not just one. Its
-      # nearest donors, verified against sklearn.impute.KNNImputer on this
-      # same matrix, are rows 1 and 4 (avg 10.0/11.0 on their shared column),
-      # not rows 0 and 1.
+      # row 3 has three missing values; nearest donors per sklearn are rows 1 and 4, not 0 and 1
       assert statistics ==
                Nx.tensor([
                  [:nan, :nan, :nan, :nan],
@@ -55,8 +52,7 @@ defmodule KNNImputterTest do
 
       assert missing_values == :nan
 
-      # with a single neighbor, sklearn picks row 4 as row 3's closest donor
-      # on their one shared column, not row 0.
+      # with 1 neighbor, sklearn picks row 4 as row 3's closest donor, not row 0
       assert statistics ==
                Nx.tensor([
                  [:nan, :nan, :nan, :nan],
@@ -109,12 +105,8 @@ defmodule KNNImputterTest do
     end
 
     test "picks donors by actual distance for a row with two missing values, not by row index" do
-      # Rows 0 and 1 are low-index but far from row 2 on their one shared
-      # column; rows 5 and 6 are high-index but genuinely close. A row with
-      # two missing values must still be matched to its real nearest
-      # neighbors instead of defaulting to the first num_neighbors rows.
-      # Reference: sklearn.impute.KNNImputer(n_neighbors=2) on this matrix
-      # imputes row 2 to [55.0, 85.0, 5.0].
+      # rows 0/1 are low-index but far from row 2; rows 5/6 are high-index but close.
+      # sklearn.impute.KNNImputer(n_neighbors=2) imputes row 2 to [55.0, 85.0, 5.0]
       x =
         Nx.tensor([
           [1.0, 2.0, 500.0],
@@ -130,16 +122,12 @@ defmodule KNNImputterTest do
       result = KNNImputter.transform(imputer, x)
 
       assert_all_close(result[2], Nx.tensor([55.0, 85.0, 5.0]))
-      # row 3 has a single missing value, unaffected by the multi-NaN bug,
-      # and its nearest donors on cols 0/1 are rows 0 and 1.
+      # row 3 has a single missing value, unaffected by the bug this fixes
       assert_all_close(result[3], Nx.tensor([1.3, 2.3, 550.0]))
     end
 
     test "keeps the input's float type through fit and transform" do
-      # row_distances and the NaN placeholder used to default to f32
-      # regardless of the input type, so an f64 tensor crashed inside the
-      # while loop as soon as a value needed imputing (type mismatch
-      # between the f32 accumulator and the f64 result).
+      # the distance accumulator and NaN placeholder used to hardcode f32
       x =
         Nx.tensor(
           [

--- a/test/scholar/impute/knn_imputter_test.exs
+++ b/test/scholar/impute/knn_imputter_test.exs
@@ -21,12 +21,16 @@ defmodule KNNImputterTest do
 
       assert missing_values == :nan
 
+      # row 3 has three missing values (cols 0, 1, 2), not just one. Its
+      # nearest donors, verified against sklearn.impute.KNNImputer on this
+      # same matrix, are rows 1 and 4 (avg 10.0/11.0 on their shared column),
+      # not rows 0 and 1.
       assert statistics ==
                Nx.tensor([
                  [:nan, :nan, :nan, :nan],
                  [:nan, :nan, :nan, :nan],
                  [:nan, :nan, 4.0, 5.0],
-                 [2.0, 3.0, 4.0, :nan],
+                 [10.0, 11.0, 6.0, :nan],
                  [:nan, :nan, :nan, :nan]
                ])
 
@@ -35,7 +39,7 @@ defmodule KNNImputterTest do
                  [0.0, 1.0, 2.0, 3.0],
                  [4.0, 5.0, 6.0, 7.0],
                  [8.0, 9.0, 4.0, 5.0],
-                 [2.0, 3.0, 4.0, 15.0],
+                 [10.0, 11.0, 6.0, 15.0],
                  [16.0, 17.0, 6.0, 19.0]
                ])
     end
@@ -51,12 +55,14 @@ defmodule KNNImputterTest do
 
       assert missing_values == :nan
 
+      # with a single neighbor, sklearn picks row 4 as row 3's closest donor
+      # on their one shared column, not row 0.
       assert statistics ==
                Nx.tensor([
                  [:nan, :nan, :nan, :nan],
                  [:nan, :nan, :nan, :nan],
-                 [:nan, :nan, 2.0, 3.0],
-                 [0.0, 1.0, 2.0, :nan],
+                 [:nan, :nan, 6.0, 7.0],
+                 [16.0, 17.0, 6.0, :nan],
                  [:nan, :nan, :nan, :nan]
                ])
 
@@ -64,8 +70,8 @@ defmodule KNNImputterTest do
                Nx.tensor([
                  [0.0, 1.0, 2.0, 3.0],
                  [4.0, 5.0, 6.0, 7.0],
-                 [8.0, 9.0, 2.0, 3.0],
-                 [0.0, 1.0, 2.0, 15.0],
+                 [8.0, 9.0, 6.0, 7.0],
+                 [16.0, 17.0, 6.0, 15.0],
                  [16.0, 17.0, 6.0, 19.0]
                ])
     end
@@ -100,6 +106,33 @@ defmodule KNNImputterTest do
                  [2.0, 3.0, 4.0, 15.0],
                  [16.0, 17.0, 6.0, 5.0]
                ])
+    end
+
+    test "picks donors by actual distance for a row with two missing values, not by row index" do
+      # Rows 0 and 1 are low-index but far from row 2 on their one shared
+      # column; rows 5 and 6 are high-index but genuinely close. A row with
+      # two missing values must still be matched to its real nearest
+      # neighbors instead of defaulting to the first num_neighbors rows.
+      # Reference: sklearn.impute.KNNImputer(n_neighbors=2) on this matrix
+      # imputes row 2 to [55.0, 85.0, 5.0].
+      x =
+        Nx.tensor([
+          [1.0, 2.0, 500.0],
+          [1.1, 2.1, 600.0],
+          [:nan, :nan, 5.0],
+          [1.3, 2.3, :nan],
+          [10.0, 20.0, 700.0],
+          [50.0, 80.0, 5.1],
+          [60.0, 90.0, 4.9]
+        ])
+
+      imputer = KNNImputter.fit(x, num_neighbors: 2)
+      result = KNNImputter.transform(imputer, x)
+
+      assert_all_close(result[2], Nx.tensor([55.0, 85.0, 5.0]))
+      # row 3 has a single missing value, unaffected by the multi-NaN bug,
+      # and its nearest donors on cols 0/1 are rows 0 and 1.
+      assert_all_close(result[3], Nx.tensor([1.3, 2.3, 550.0]))
     end
   end
 

--- a/test/scholar/impute/knn_imputter_test.exs
+++ b/test/scholar/impute/knn_imputter_test.exs
@@ -134,6 +134,30 @@ defmodule KNNImputterTest do
       # and its nearest donors on cols 0/1 are rows 0 and 1.
       assert_all_close(result[3], Nx.tensor([1.3, 2.3, 550.0]))
     end
+
+    test "keeps the input's float type through fit and transform" do
+      # row_distances and the NaN placeholder used to default to f32
+      # regardless of the input type, so an f64 tensor crashed inside the
+      # while loop as soon as a value needed imputing (type mismatch
+      # between the f32 accumulator and the f64 result).
+      x =
+        Nx.tensor(
+          [
+            [0.1, 0.2, 500.123456789],
+            [0.11, 0.21, 600.987654321],
+            [:nan, :nan, 5.000000001],
+            [50.0, 80.0, 5.100000002],
+            [60.0, 90.0, 4.900000003]
+          ],
+          type: :f64
+        )
+
+      imputer = KNNImputter.fit(x, num_neighbors: 2)
+      result = KNNImputter.transform(imputer, x)
+
+      assert Nx.type(result) == {:f, 64}
+      assert_all_close(result[2], Nx.tensor([55.0, 85.0, 5.0], type: :f64), atol: 1.0e-9)
+    end
   end
 
   describe "errors" do


### PR DESCRIPTION
`KNNImputer` computes distance to a candidate donor by zeroing out only the single column currently being filled. Any other missing value in that same row is left as NaN, so it poisons the distance sum for every donor. Every candidate ends up at infinity, and picking "nearest" from a constant array just returns the first `num_neighbors` rows in the tensor. So any row with two or more missing values gets imputed from the first rows in the data instead of its real nearest neighbors, silently.

Fixed by excluding any column where either row has NaN, not just the one being filled, matching the present-features weighting `sklearn.impute.KNNImputer`'s `nan_euclidean_distances` uses. Verified against it directly: on a case where the true nearest donors sit far from the ones the old code always picked, the old code returns `[1.05, 2.05, 5.0]`, this returns `[55.0, 85.0, 5.0]`, matching sklearn exactly.

Also fixed a separate bug found while testing: the distance accumulator and the NaN placeholder both hardcoded f32, so an f64 tensor crashed as soon as a value needed imputing. Both now take their type from the input.