### PR TITLE
Fix confusion_matrix raising on tensor sample weights

### DIFF
--- a/lib/scholar/shared.ex
+++ b/lib/scholar/shared.ex
@@ -59,7 +59,9 @@ defmodule Scholar.Shared do
         Nx.tensor(weights, type: type)
 
       Nx.is_tensor(weights) and Nx.shape(weights) in [{}, {num_samples}] ->
-        weights |> Nx.broadcast({num_samples}) |> Nx.as_type(type)
+        weights = Nx.broadcast(weights, {num_samples})
+        # :type is optional, and the branches above already work without it
+        if type, do: Nx.as_type(weights, type), else: weights
 
       true ->
         raise ArgumentError,

--- a/test/scholar/metrics/classification_test.exs
+++ b/test/scholar/metrics/classification_test.exs
@@ -4,6 +4,40 @@ defmodule Scholar.Metrics.ClassificationTest do
   alias Scholar.Metrics.Classification
   doctest Classification
 
+  test "confusion_matrix - sample weights as a tensor match the same weights as a list" do
+    y_true = Nx.tensor([0, 0, 1, 1], type: :u32)
+    y_pred = Nx.tensor([0, 1, 1, 1], type: :u32)
+
+    from_list =
+      Classification.confusion_matrix(y_true, y_pred,
+        num_classes: 2,
+        sample_weights: [1, 2, 1, 1]
+      )
+
+    from_tensor =
+      Classification.confusion_matrix(y_true, y_pred,
+        num_classes: 2,
+        sample_weights: Nx.tensor([1, 2, 1, 1])
+      )
+
+    assert from_tensor == from_list
+  end
+
+  test "confusion_matrix - a scalar sample weight applies to every sample" do
+    y_true = Nx.tensor([0, 0, 1, 1], type: :u32)
+    y_pred = Nx.tensor([0, 1, 1, 1], type: :u32)
+
+    weighted =
+      Classification.confusion_matrix(y_true, y_pred,
+        num_classes: 2,
+        sample_weights: Nx.tensor(2)
+      )
+
+    unweighted = Classification.confusion_matrix(y_true, y_pred, num_classes: 2)
+
+    assert Nx.to_flat_list(weighted) == Nx.to_flat_list(Nx.multiply(unweighted, 2))
+  end
+
   test "roc_curve - y_score with repeated elements" do
     y_score = Nx.tensor([0.1, 0.1, 0.2, 0.2, 0.3, 0.3])
     y_true = Nx.tensor([0, 0, 1, 1, 1, 1])


### PR DESCRIPTION
`Scholar.Metrics.Classification.confusion_matrix/3` takes `:sample_weights` as a list but raises on a tensor:

```elixir
y_true = Nx.tensor([0, 0, 1, 1], type: :u32)
y_pred = Nx.tensor([0, 1, 1, 1], type: :u32)

Classification.confusion_matrix(y_true, y_pred, num_classes: 2, sample_weights: [1, 2, 1, 1])
#Nx.Tensor<
  s64[2][2]
  [
    [1, 2],
    [0, 2]
  ]
>

Classification.confusion_matrix(y_true, y_pred, num_classes: 2, sample_weights: Nx.tensor([1, 2, 1, 1]))
** (ArgumentError) invalid numerical type: nil (see Nx.Type docs for all supported types)
```

A scalar weight tensor fails the same way. Both shapes are accepted input: `Scholar.Options.weights` validates rank 0 and rank 1 tensors, and `validate_weights/3` lists `[{}, {num_samples}]` among the shapes it handles. So the option accepts shapes the implementation then rejects, and the error names none of it.

`Shared.validate_weights/3` reads `:type` from its opts, which is optional. The nil and list branches work without it, since `Nx.tensor(weights, type: nil)` infers the type. The tensor branch calls `Nx.as_type(weights, nil)`, which raises. Of the ten call sites, `confusion_matrix` is the only one that passes no type, so it is the only one that reaches this.

The fix converts only when a type is given, which leaves the tensor branch behaving like the list branch: the weights keep their own type.

Fixing it at the call site instead, passing `to_float_type(y_true)` like the other callers do, also works but changes what the function returns. An unnormalized count matrix built from integer weights would come back as floats.

Two tests cover it: tensor weights matching the same weights as a list, and a scalar weight applying to every sample.